### PR TITLE
update dependencies to meet Node 10 requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,148 +1,551 @@
 {
-    "name": "osc.js-examples-node",
-    "version": "0.1.1",
+    "name": "osc-node",
+    "version": "0.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "npm": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
-            "integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
+        "@serialport/binding-abstract": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-2.0.5.tgz",
+            "integrity": "sha512-oRg0QRsXJFKHQbQjmo0regKLZ9JhjLmTqc47ocJgYM5UtU9Q1VFrVPh0B2lr2pfm/tr3aNvTLX1eiVAvXyZ/bg==",
+            "optional": true,
             "requires": {
-                "JSONStream": "1.3.2",
-                "abbrev": "1.1.1",
-                "ansi-regex": "3.0.0",
-                "ansicolors": "0.3.2",
-                "ansistyles": "0.1.3",
-                "aproba": "1.2.0",
-                "archy": "1.0.0",
-                "bin-links": "1.1.0",
-                "bluebird": "3.5.1",
-                "cacache": "10.0.4",
-                "call-limit": "1.1.0",
-                "chownr": "1.0.1",
-                "cli-table2": "0.2.0",
-                "cmd-shim": "2.0.2",
-                "columnify": "1.5.4",
-                "config-chain": "1.1.11",
-                "debuglog": "1.0.1",
-                "detect-indent": "5.0.0",
-                "dezalgo": "1.0.3",
-                "editor": "1.0.0",
-                "find-npm-prefix": "1.0.2",
-                "fs-vacuum": "1.2.10",
-                "fs-write-stream-atomic": "1.0.10",
-                "gentle-fs": "2.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "has-unicode": "2.0.1",
-                "hosted-git-info": "2.5.0",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "ini": "1.3.5",
-                "init-package-json": "1.10.1",
-                "is-cidr": "1.0.0",
-                "lazy-property": "1.0.0",
-                "libcipm": "1.3.3",
-                "libnpx": "9.7.1",
-                "lockfile": "1.0.3",
-                "lodash._baseindexof": "3.1.0",
-                "lodash._baseuniq": "4.6.0",
-                "lodash._bindcallback": "3.0.1",
-                "lodash._cacheindexof": "3.0.2",
-                "lodash._createcache": "3.1.2",
-                "lodash._getnative": "3.9.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.restparam": "3.6.1",
-                "lodash.union": "4.6.0",
-                "lodash.uniq": "4.5.0",
-                "lodash.without": "4.4.0",
-                "lru-cache": "4.1.1",
-                "meant": "1.0.1",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "nopt": "4.0.1",
-                "normalize-package-data": "2.4.0",
-                "npm-cache-filename": "1.0.2",
-                "npm-install-checks": "3.0.0",
-                "npm-lifecycle": "2.0.0",
-                "npm-package-arg": "6.0.0",
-                "npm-packlist": "1.1.10",
-                "npm-profile": "3.0.1",
-                "npm-registry-client": "8.5.0",
-                "npm-user-validate": "1.0.0",
-                "npmlog": "4.1.2",
-                "once": "1.4.0",
-                "opener": "1.4.3",
-                "osenv": "0.1.5",
-                "pacote": "7.3.3",
-                "path-is-inside": "1.0.2",
-                "promise-inflight": "1.0.1",
-                "qrcode-terminal": "0.11.0",
-                "query-string": "5.1.0",
-                "qw": "1.0.1",
-                "read": "1.0.7",
-                "read-cmd-shim": "1.0.1",
-                "read-installed": "4.0.3",
-                "read-package-json": "2.0.12",
-                "read-package-tree": "5.1.6",
-                "readable-stream": "2.3.4",
-                "readdir-scoped-modules": "1.0.2",
-                "request": "2.83.0",
-                "retry": "0.10.1",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.1",
-                "semver": "5.5.0",
-                "sha": "2.0.1",
-                "slide": "1.1.6",
-                "sorted-object": "2.0.1",
-                "sorted-union-stream": "2.1.3",
-                "ssri": "5.2.4",
-                "strip-ansi": "4.0.0",
-                "tar": "4.3.3",
-                "text-table": "0.2.0",
+                "debug": "^4.1.1"
+            }
+        },
+        "@serialport/binding-mock": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-2.0.5.tgz",
+            "integrity": "sha512-1kD1qI686pIIolGZ6TPjAtvy8c3XIUlE4OXRZf7ZHaZgGaOUHAUMLKZt4tNTxsfedRTFyiYyHoe5QAbx82R9pQ==",
+            "optional": true,
+            "requires": {
+                "@serialport/binding-abstract": "^2.0.5",
+                "debug": "^4.1.1"
+            }
+        },
+        "@serialport/bindings": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-2.0.8.tgz",
+            "integrity": "sha512-paKLa9JkoH5FAy2sATTdXLCiKpuKn0pN15/etcCqzX8vi25fnQgJ8Yx9Z6zdbcKe1No7s/9PuH9yfjDR61fbOQ==",
+            "optional": true,
+            "requires": {
+                "@serialport/binding-abstract": "^2.0.5",
+                "@serialport/parser-readline": "^2.0.2",
+                "bindings": "^1.3.0",
+                "debug": "^4.1.1",
+                "nan": "^2.13.2",
+                "prebuild-install": "^5.2.1"
+            }
+        },
+        "@serialport/parser-byte-length": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-2.0.2.tgz",
+            "integrity": "sha512-cUOprk1uRLucCJy6m+wAM4pwdBaB5D4ySi6juwRScP9DTjKUvGWYj5jzuqvftFBvYFmFza89aLj5K23xiiqj7Q==",
+            "optional": true
+        },
+        "@serialport/parser-cctalk": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-2.0.2.tgz",
+            "integrity": "sha512-5LMysRv7De+TeeoKzi4+sgouD4tqZEAn1agAVevw+7ILM0m30i1zgZLtchgxtCH7OoQRAkENEVEPc0OwhghKgw==",
+            "optional": true
+        },
+        "@serialport/parser-delimiter": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-2.0.2.tgz",
+            "integrity": "sha512-zB02LahFfyZmJqak9l37vP/F1K+KCUxd1KQj35OhD1+0q/unMjVTZmsfkxFSM4gkaxP9j7+8USk+LQJ3V8U26Q==",
+            "optional": true
+        },
+        "@serialport/parser-readline": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-2.0.2.tgz",
+            "integrity": "sha512-thL26dGEHB+eINNydJmzcLLhiqcBQkF+wNTbRaYblTP/6dm7JsfjYSud7bTkN63AgE0xpe9tKXBFqc8zgJ1VKg==",
+            "optional": true,
+            "requires": {
+                "@serialport/parser-delimiter": "^2.0.2"
+            }
+        },
+        "@serialport/parser-ready": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-2.0.2.tgz",
+            "integrity": "sha512-6ynQ+HIIkFQcEO2Hrq4Qmdz+hlJ7kjTHGQ1E7SRN7f70nnys1v3HSke8mjK3RzVw+SwL0rBYjftUdCTrU+7c+Q==",
+            "optional": true
+        },
+        "@serialport/parser-regex": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-2.0.2.tgz",
+            "integrity": "sha512-7qjYd7AdHUK8fJOmHpXlMRipqRCVMMyDFyf/5TQQiOt6q+BiFjLOtSpVXhakHwgnXanzDYKeRSB8zM0pZZg+LA==",
+            "optional": true
+        },
+        "@serialport/stream": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-2.0.5.tgz",
+            "integrity": "sha512-9gc3zPoAqs/04mvq8TdZ7GxtnacCDuw3/u0u18UXXHgC/5tNDYkY+hXFIJB1fQFnP5yyNB1L2XLfX974ySJg9Q==",
+            "optional": true,
+            "requires": {
+                "@serialport/binding-mock": "^2.0.5",
+                "debug": "^4.1.1"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "optional": true
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "optional": true
+        },
+        "are-we-there-yet": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+            "optional": true,
+            "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "bl": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+            "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+            "optional": true,
+            "requires": {
+                "readable-stream": "^3.0.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+                    "optional": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "chownr": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+            "optional": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "optional": true
+        },
+        "console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "optional": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "optional": true
+        },
+        "debug": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "optional": true,
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "decompress-response": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "optional": true,
+            "requires": {
+                "mimic-response": "^2.0.0"
+            }
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "optional": true
+        },
+        "delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "optional": true
+        },
+        "detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+            "optional": true
+        },
+        "end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "optional": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "optional": true
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "optional": true
+        },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "optional": true
+        },
+        "gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "optional": true,
+            "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
+        "github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+            "optional": true
+        },
+        "has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "optional": true
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "optional": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "optional": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "optional": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "optional": true
+        },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "mimic-response": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+            "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+            "optional": true
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "optional": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "optional": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "optional": true
+                }
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "optional": true
+        },
+        "nan": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+            "optional": true
+        },
+        "napi-build-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+            "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+            "optional": true
+        },
+        "node-abi": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.12.0.tgz",
+            "integrity": "sha512-VhPBXCIcvmo/5K8HPmnWJyyhvgKxnHTUMXR/XwGHV68+wrgkzST4UmQrY/XszSWA5dtnXpNp528zkcyJ/pzVcw==",
+            "optional": true,
+            "requires": {
+                "semver": "^5.4.1"
+            }
+        },
+        "node-cmd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/node-cmd/-/node-cmd-3.0.0.tgz",
+            "integrity": "sha1-OP/3CkqqT2WdID61eGJzcBjiT28="
+        },
+        "node-omxplayer": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/node-omxplayer/-/node-omxplayer-0.6.1.tgz",
+            "integrity": "sha512-yRhzO8iDwN6fzMs862xrCDu4vnjpRmus8yzu2S9WP14OqgeB0epdKipJro+C9iqIQ6OD5Ao25ZuftZ1Lw/kisA=="
+        },
+        "noop-logger": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+            "optional": true
+        },
+        "npm": {
+            "version": "6.12.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.12.0.tgz",
+            "integrity": "sha512-juj5VkB3/k+PWbJUnXD7A/8oc8zLusDnK/sV9PybSalsbOVOTIp5vSE0rz5rQ7BsmUgQS47f/L2GYQnWXaKgnQ==",
+            "requires": {
+                "JSONStream": "^1.3.5",
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "^2.0.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.3",
+                "bluebird": "^3.5.5",
+                "byte-size": "^5.0.1",
+                "cacache": "^12.0.3",
+                "call-limit": "^1.1.1",
+                "chownr": "^1.1.2",
+                "ci-info": "^2.0.0",
+                "cli-columns": "^3.1.2",
+                "cli-table3": "^0.5.1",
+                "cmd-shim": "^3.0.3",
+                "columnify": "~1.5.4",
+                "config-chain": "^1.1.12",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "detect-newline": "^2.1.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.2.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.2",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "^2.8.5",
+                "iferr": "^1.0.2",
+                "imurmurhash": "*",
+                "infer-owner": "^1.0.4",
+                "inflight": "~1.0.6",
+                "inherits": "^2.0.4",
+                "ini": "^1.3.5",
+                "init-package-json": "^1.10.3",
+                "is-cidr": "^3.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^4.0.4",
+                "libnpm": "^3.0.1",
+                "libnpmaccess": "^3.0.2",
+                "libnpmhook": "^5.0.3",
+                "libnpmorg": "^1.0.1",
+                "libnpmsearch": "^2.0.2",
+                "libnpmteam": "^1.0.2",
+                "libnpx": "^10.2.0",
+                "lock-verify": "^2.1.0",
+                "lockfile": "^1.0.4",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "^5.1.1",
+                "meant": "~1.0.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "^1.0.1",
+                "node-gyp": "^5.0.5",
+                "nopt": "~4.0.1",
+                "normalize-package-data": "^2.5.0",
+                "npm-audit-report": "^1.3.2",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "^3.0.2",
+                "npm-lifecycle": "^3.1.4",
+                "npm-package-arg": "^6.1.1",
+                "npm-packlist": "^1.4.4",
+                "npm-pick-manifest": "^3.0.2",
+                "npm-profile": "^4.0.2",
+                "npm-registry-fetch": "^4.0.0",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "^1.5.1",
+                "osenv": "^0.1.5",
+                "pacote": "^9.5.8",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "query-string": "^6.8.2",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "^1.0.4",
+                "read-installed": "~4.0.3",
+                "read-package-json": "^2.1.0",
+                "read-package-tree": "^5.3.1",
+                "readable-stream": "^3.4.0",
+                "readdir-scoped-modules": "^1.1.0",
+                "request": "^2.88.0",
+                "retry": "^0.12.0",
+                "rimraf": "^2.6.3",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.7.1",
+                "sha": "^3.0.0",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^6.0.1",
+                "stringify-package": "^1.0.1",
+                "tar": "^4.4.12",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
                 "uid-number": "0.0.6",
-                "umask": "1.1.0",
-                "unique-filename": "1.1.0",
-                "unpipe": "1.0.0",
-                "update-notifier": "2.3.0",
-                "uuid": "3.2.1",
-                "validate-npm-package-license": "3.0.1",
-                "validate-npm-package-name": "3.0.0",
-                "which": "1.3.0",
-                "worker-farm": "1.5.2",
-                "wrappy": "1.0.2",
-                "write-file-atomic": "2.1.0"
+                "umask": "~1.1.0",
+                "unique-filename": "^1.1.1",
+                "unpipe": "~1.0.0",
+                "update-notifier": "^2.5.0",
+                "uuid": "^3.3.2",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "^1.3.1",
+                "worker-farm": "^1.7.0",
+                "write-file-atomic": "^2.4.3"
             },
             "dependencies": {
                 "JSONStream": {
-                    "version": "1.3.2",
+                    "version": "1.3.5",
                     "bundled": true,
                     "requires": {
-                        "jsonparse": "1.3.1",
-                        "through": "2.3.8"
-                    },
-                    "dependencies": {
-                        "jsonparse": {
-                            "version": "1.3.1",
-                            "bundled": true
-                        },
-                        "through": {
-                            "version": "2.3.8",
-                            "bundled": true
-                        }
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
                     }
                 },
                 "abbrev": {
                     "version": "1.1.1",
                     "bundled": true
                 },
+                "agent-base": {
+                    "version": "4.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "es6-promisify": "^5.0.0"
+                    }
+                },
+                "agentkeepalive": {
+                    "version": "3.5.2",
+                    "bundled": true,
+                    "requires": {
+                        "humanize-ms": "^1.2.1"
+                    }
+                },
+                "ajv": {
+                    "version": "5.5.2",
+                    "bundled": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "ansi-align": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^2.0.0"
+                    }
+                },
                 "ansi-regex": {
-                    "version": "3.0.0",
+                    "version": "2.1.1",
                     "bundled": true
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
                 },
                 "ansicolors": {
                     "version": "0.3.2",
@@ -153,186 +556,429 @@
                     "bundled": true
                 },
                 "aproba": {
-                    "version": "1.2.0",
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "archy": {
                     "version": "1.0.0",
                     "bundled": true
                 },
-                "bin-links": {
-                    "version": "1.1.0",
+                "are-we-there-yet": {
+                    "version": "1.1.4",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "cmd-shim": "2.0.2",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "gentle-fs": "2.0.1",
-                        "graceful-fs": "4.1.11",
-                        "slide": "1.1.6"
-                    }
-                },
-                "bluebird": {
-                    "version": "3.5.1",
-                    "bundled": true
-                },
-                "cacache": {
-                    "version": "10.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "bluebird": "3.5.1",
-                        "chownr": "1.0.1",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "lru-cache": "4.1.1",
-                        "mississippi": "2.0.0",
-                        "mkdirp": "0.5.1",
-                        "move-concurrently": "1.0.1",
-                        "promise-inflight": "1.0.1",
-                        "rimraf": "2.6.2",
-                        "ssri": "5.2.4",
-                        "unique-filename": "1.1.0",
-                        "y18n": "4.0.0"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     },
                     "dependencies": {
-                        "y18n": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        }
-                    }
-                },
-                "call-limit": {
-                    "version": "1.1.0",
-                    "bundled": true
-                },
-                "chownr": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "cli-table2": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "colors": "1.1.2",
-                        "lodash": "3.10.1",
-                        "string-width": "1.0.2"
-                    },
-                    "dependencies": {
-                        "colors": {
-                            "version": "1.1.2",
-                            "bundled": true,
-                            "optional": true
-                        },
-                        "lodash": {
-                            "version": "3.10.1",
-                            "bundled": true
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
+                        "readable-stream": {
+                            "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
-                            },
-                            "dependencies": {
-                                "code-point-at": {
-                                    "version": "1.1.0",
-                                    "bundled": true
-                                },
-                                "is-fullwidth-code-point": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "number-is-nan": "1.0.1"
-                                    },
-                                    "dependencies": {
-                                        "number-is-nan": {
-                                            "version": "1.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "strip-ansi": {
-                                    "version": "3.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "ansi-regex": "2.1.1"
-                                    },
-                                    "dependencies": {
-                                        "ansi-regex": {
-                                            "version": "2.1.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
                 },
-                "cmd-shim": {
-                    "version": "2.0.2",
+                "asap": {
+                    "version": "2.0.6",
+                    "bundled": true
+                },
+                "asn1": {
+                    "version": "0.2.4",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "mkdirp": "0.5.1"
+                        "safer-buffer": "~2.1.0"
                     }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "bundled": true
+                },
+                "aws4": {
+                    "version": "1.8.0",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "^0.14.3"
+                    }
+                },
+                "bin-links": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "bluebird": "^3.5.3",
+                        "cmd-shim": "^3.0.0",
+                        "gentle-fs": "^2.0.1",
+                        "graceful-fs": "^4.1.15",
+                        "write-file-atomic": "^2.3.0"
+                    }
+                },
+                "bluebird": {
+                    "version": "3.5.5",
+                    "bundled": true
+                },
+                "boxen": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^2.0.0"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-from": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "builtins": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "byline": {
+                    "version": "5.0.0",
+                    "bundled": true
+                },
+                "byte-size": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "cacache": {
+                    "version": "12.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "bluebird": "^3.5.5",
+                        "chownr": "^1.1.1",
+                        "figgy-pudding": "^3.5.1",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.1.15",
+                        "infer-owner": "^1.0.3",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.3",
+                        "ssri": "^6.0.1",
+                        "unique-filename": "^1.1.1",
+                        "y18n": "^4.0.0"
+                    }
+                },
+                "call-limit": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "bundled": true
+                },
+                "capture-stack-trace": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.2",
+                    "bundled": true
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "cidr-regex": {
+                    "version": "2.0.10",
+                    "bundled": true,
+                    "requires": {
+                        "ip-regex": "^2.1.0"
+                    }
+                },
+                "cli-boxes": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "cli-columns": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^2.0.0",
+                        "strip-ansi": "^3.0.1"
+                    }
+                },
+                "cli-table3": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "colors": "^1.1.2",
+                        "object-assign": "^4.1.0",
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "clone": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "cmd-shim": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
+                    }
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "color-convert": {
+                    "version": "1.9.1",
+                    "bundled": true,
+                    "requires": {
+                        "color-name": "^1.1.1"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "bundled": true
+                },
+                "colors": {
+                    "version": "1.3.3",
+                    "bundled": true,
+                    "optional": true
                 },
                 "columnify": {
                     "version": "1.5.4",
                     "bundled": true,
                     "requires": {
-                        "strip-ansi": "3.0.1",
-                        "wcwidth": "1.0.1"
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
+                    }
+                },
+                "combined-stream": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "bundled": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                     },
                     "dependencies": {
-                        "strip-ansi": {
-                            "version": "3.0.1",
+                        "readable-stream": {
+                            "version": "2.3.6",
                             "bundled": true,
                             "requires": {
-                                "ansi-regex": "2.1.1"
-                            },
-                            "dependencies": {
-                                "ansi-regex": {
-                                    "version": "2.1.1",
-                                    "bundled": true
-                                }
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
-                        "wcwidth": {
-                            "version": "1.0.1",
+                        "string_decoder": {
+                            "version": "1.1.1",
                             "bundled": true,
                             "requires": {
-                                "defaults": "1.0.3"
-                            },
-                            "dependencies": {
-                                "defaults": {
-                                    "version": "1.0.3",
-                                    "bundled": true,
-                                    "requires": {
-                                        "clone": "1.0.2"
-                                    },
-                                    "dependencies": {
-                                        "clone": {
-                                            "version": "1.0.2",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
                 },
                 "config-chain": {
-                    "version": "1.1.11",
+                    "version": "1.1.12",
                     "bundled": true,
                     "requires": {
-                        "ini": "1.3.5",
-                        "proto-list": "1.2.4"
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
+                    }
+                },
+                "configstore": {
+                    "version": "3.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "dot-prop": "^4.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "copy-concurrently": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^1.1.1",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.0"
                     },
                     "dependencies": {
-                        "proto-list": {
-                            "version": "1.2.4",
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true
+                        }
+                    }
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "create-error-class": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "capture-stack-trace": "^1.0.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "4.1.5",
+                            "bundled": true,
+                            "requires": {
+                                "pseudomap": "^1.0.2",
+                                "yallist": "^2.1.2"
+                            }
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true
+                        }
+                    }
+                },
+                "crypto-random-string": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "cyclist": {
+                    "version": "0.2.2",
+                    "bundled": true
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
                             "bundled": true
                         }
                     }
@@ -341,116 +987,521 @@
                     "version": "1.0.1",
                     "bundled": true
                 },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "decode-uri-component": {
+                    "version": "0.2.0",
+                    "bundled": true
+                },
+                "deep-extend": {
+                    "version": "0.5.1",
+                    "bundled": true
+                },
+                "defaults": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "clone": "^1.0.2"
+                    }
+                },
+                "define-properties": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "object-keys": "^1.0.12"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
                 "detect-indent": {
                     "version": "5.0.0",
+                    "bundled": true
+                },
+                "detect-newline": {
+                    "version": "2.1.0",
                     "bundled": true
                 },
                 "dezalgo": {
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "asap": "2.0.5",
-                        "wrappy": "1.0.2"
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
+                    }
+                },
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "is-obj": "^1.0.0"
+                    }
+                },
+                "dotenv": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "duplexer3": {
+                    "version": "0.1.4",
+                    "bundled": true
+                },
+                "duplexify": {
+                    "version": "3.6.0",
+                    "bundled": true,
+                    "requires": {
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                     },
                     "dependencies": {
-                        "asap": {
-                            "version": "2.0.5",
-                            "bundled": true
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
                         }
+                    }
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "editor": {
                     "version": "1.0.0",
                     "bundled": true
                 },
+                "encoding": {
+                    "version": "0.1.12",
+                    "bundled": true,
+                    "requires": {
+                        "iconv-lite": "~0.4.13"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "requires": {
+                        "once": "^1.4.0"
+                    }
+                },
+                "env-paths": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "err-code": {
+                    "version": "1.1.2",
+                    "bundled": true
+                },
+                "errno": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "requires": {
+                        "prr": "~1.0.1"
+                    }
+                },
+                "es-abstract": {
+                    "version": "1.12.0",
+                    "bundled": true,
+                    "requires": {
+                        "es-to-primitive": "^1.1.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.1",
+                        "is-callable": "^1.1.3",
+                        "is-regex": "^1.0.4"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
+                    }
+                },
+                "es6-promise": {
+                    "version": "4.2.8",
+                    "bundled": true
+                },
+                "es6-promisify": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "es6-promise": "^4.0.3"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
+                "extsprintf": {
+                    "version": "1.3.0",
+                    "bundled": true
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "fast-json-stable-stringify": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "figgy-pudding": {
+                    "version": "3.5.1",
+                    "bundled": true
+                },
                 "find-npm-prefix": {
                     "version": "1.0.2",
                     "bundled": true
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "flush-write-stream": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "from2": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "fs-minipass": {
+                    "version": "1.2.7",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^2.6.0"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "2.8.6",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        }
+                    }
                 },
                 "fs-vacuum": {
                     "version": "1.2.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "path-is-inside": "1.0.2",
-                        "rimraf": "2.6.2"
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
                     }
                 },
                 "fs-write-stream-atomic": {
                     "version": "1.0.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "imurmurhash": "0.1.4",
-                        "readable-stream": "2.3.4"
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
+                    },
+                    "dependencies": {
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
-                "gentle-fs": {
-                    "version": "2.0.1",
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "fs-vacuum": "1.2.10",
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "mkdirp": "0.5.1",
-                        "path-is-inside": "1.0.2",
-                        "read-cmd-shim": "1.0.1",
-                        "slide": "1.1.6"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "genfun": {
+                    "version": "5.0.0",
+                    "bundled": true
+                },
+                "gentle-fs": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^1.1.2",
+                        "chownr": "^1.1.2",
+                        "fs-vacuum": "^1.2.10",
+                        "graceful-fs": "^4.1.11",
+                        "iferr": "^0.1.5",
+                        "infer-owner": "^1.0.4",
+                        "mkdirp": "^0.5.1",
+                        "path-is-inside": "^1.0.2",
+                        "read-cmd-shim": "^1.0.1",
+                        "slide": "^1.1.6"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
+                        "iferr": {
+                            "version": "0.1.5",
+                            "bundled": true
+                        }
+                    }
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0"
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.4",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "global-dirs": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "ini": "^1.3.4"
+                    }
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "bundled": true,
+                    "requires": {
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                     },
                     "dependencies": {
-                        "fs.realpath": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "minimatch": {
-                            "version": "3.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "brace-expansion": "1.1.8"
-                            },
-                            "dependencies": {
-                                "brace-expansion": {
-                                    "version": "1.1.8",
-                                    "bundled": true,
-                                    "requires": {
-                                        "balanced-match": "1.0.0",
-                                        "concat-map": "0.0.1"
-                                    },
-                                    "dependencies": {
-                                        "balanced-match": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        },
-                                        "concat-map": {
-                                            "version": "0.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "path-is-absolute": {
-                            "version": "1.0.1",
+                        "get-stream": {
+                            "version": "3.0.0",
                             "bundled": true
                         }
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.11",
+                    "version": "4.2.2",
+                    "bundled": true
+                },
+                "har-schema": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "har-validator": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "has": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "has-symbols": {
+                    "version": "1.0.0",
                     "bundled": true
                 },
                 "has-unicode": {
@@ -458,27 +1509,85 @@
                     "bundled": true
                 },
                 "hosted-git-info": {
-                    "version": "2.5.0",
+                    "version": "2.8.5",
                     "bundled": true
                 },
+                "http-cache-semantics": {
+                    "version": "3.8.1",
+                    "bundled": true
+                },
+                "http-proxy-agent": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "agent-base": "4",
+                        "debug": "3.1.0"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.2",
+                    "bundled": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    }
+                },
+                "humanize-ms": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "ms": "^2.0.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "bundled": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
                 "iferr": {
-                    "version": "0.1.5",
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "import-lazy": {
+                    "version": "2.1.0",
                     "bundled": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
                     "bundled": true
                 },
+                "infer-owner": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
-                    "version": "2.0.3",
+                    "version": "2.0.4",
                     "bundled": true
                 },
                 "ini": {
@@ -486,532 +1595,375 @@
                     "bundled": true
                 },
                 "init-package-json": {
-                    "version": "1.10.1",
+                    "version": "1.10.3",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "npm-package-arg": "5.1.2",
-                        "promzard": "0.3.0",
-                        "read": "1.0.7",
-                        "read-package-json": "2.0.12",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.1",
-                        "validate-npm-package-name": "3.0.0"
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "ip": {
+                    "version": "1.1.5",
+                    "bundled": true
+                },
+                "ip-regex": {
+                    "version": "2.1.0",
+                    "bundled": true
+                },
+                "is-callable": {
+                    "version": "1.1.4",
+                    "bundled": true
+                },
+                "is-ci": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "ci-info": "^1.0.0"
                     },
                     "dependencies": {
-                        "npm-package-arg": {
-                            "version": "5.1.2",
-                            "bundled": true,
-                            "requires": {
-                                "hosted-git-info": "2.5.0",
-                                "osenv": "0.1.5",
-                                "semver": "5.5.0",
-                                "validate-npm-package-name": "3.0.0"
-                            }
-                        },
-                        "promzard": {
-                            "version": "0.3.0",
-                            "bundled": true,
-                            "requires": {
-                                "read": "1.0.7"
-                            }
+                        "ci-info": {
+                            "version": "1.6.0",
+                            "bundled": true
                         }
                     }
                 },
                 "is-cidr": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "cidr-regex": "^2.0.10"
+                    }
+                },
+                "is-date-object": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "cidr-regex": "1.0.6"
-                    },
-                    "dependencies": {
-                        "cidr-regex": {
-                            "version": "1.0.6",
-                            "bundled": true
-                        }
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "is-installed-globally": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "global-dirs": "^0.1.0",
+                        "is-path-inside": "^1.0.0"
+                    }
+                },
+                "is-npm": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "is-obj": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.1"
+                    }
+                },
+                "is-redirect": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "is-regex": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "has": "^1.0.1"
+                    }
+                },
+                "is-retry-allowed": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "is-symbol": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "has-symbols": "^1.0.0"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "bundled": true
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "jsonparse": {
+                    "version": "1.3.1",
+                    "bundled": true
+                },
+                "jsprim": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                    }
+                },
+                "latest-version": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "package-json": "^4.0.0"
                     }
                 },
                 "lazy-property": {
                     "version": "1.0.0",
                     "bundled": true
                 },
-                "libcipm": {
-                    "version": "1.3.3",
+                "lcid": {
+                    "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "bin-links": "1.1.0",
-                        "bluebird": "3.5.1",
-                        "find-npm-prefix": "1.0.2",
-                        "graceful-fs": "4.1.11",
-                        "lock-verify": "2.0.0",
-                        "npm-lifecycle": "2.0.0",
-                        "npm-logical-tree": "1.2.1",
-                        "npm-package-arg": "6.0.0",
-                        "pacote": "7.3.3",
-                        "protoduck": "5.0.0",
-                        "read-package-json": "2.0.12",
-                        "rimraf": "2.6.2",
-                        "worker-farm": "1.5.2"
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "libcipm": {
+                    "version": "4.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.5.1",
+                        "find-npm-prefix": "^1.0.2",
+                        "graceful-fs": "^4.1.11",
+                        "ini": "^1.3.5",
+                        "lock-verify": "^2.0.2",
+                        "mkdirp": "^0.5.1",
+                        "npm-lifecycle": "^3.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "pacote": "^9.1.0",
+                        "read-package-json": "^2.0.13",
+                        "rimraf": "^2.6.2",
+                        "worker-farm": "^1.6.0"
+                    }
+                },
+                "libnpm": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.3",
+                        "find-npm-prefix": "^1.0.2",
+                        "libnpmaccess": "^3.0.2",
+                        "libnpmconfig": "^1.2.1",
+                        "libnpmhook": "^5.0.3",
+                        "libnpmorg": "^1.0.1",
+                        "libnpmpublish": "^1.1.2",
+                        "libnpmsearch": "^2.0.2",
+                        "libnpmteam": "^1.0.2",
+                        "lock-verify": "^2.0.2",
+                        "npm-lifecycle": "^3.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-profile": "^4.0.2",
+                        "npm-registry-fetch": "^4.0.0",
+                        "npmlog": "^4.1.2",
+                        "pacote": "^9.5.3",
+                        "read-package-json": "^2.0.13",
+                        "stringify-package": "^1.0.0"
+                    }
+                },
+                "libnpmaccess": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "get-stream": "^4.0.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmconfig": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "find-up": "^3.0.0",
+                        "ini": "^1.3.5"
                     },
                     "dependencies": {
-                        "find-npm-prefix": {
-                            "version": "1.0.2",
+                        "find-up": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "locate-path": "^3.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "2.2.0",
                             "bundled": true
-                        },
-                        "lock-verify": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "npm-package-arg": "5.1.2",
-                                "semver": "5.5.0"
-                            },
-                            "dependencies": {
-                                "npm-package-arg": {
-                                    "version": "5.1.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "hosted-git-info": "2.5.0",
-                                        "osenv": "0.1.5",
-                                        "semver": "5.5.0",
-                                        "validate-npm-package-name": "3.0.0"
-                                    }
-                                }
-                            }
-                        },
-                        "npm-logical-tree": {
-                            "version": "1.2.1",
-                            "bundled": true
-                        },
-                        "protoduck": {
-                            "version": "5.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "genfun": "4.0.1"
-                            },
-                            "dependencies": {
-                                "genfun": {
-                                    "version": "4.0.1",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "worker-farm": {
-                            "version": "1.5.2",
-                            "bundled": true,
-                            "requires": {
-                                "errno": "0.1.7",
-                                "xtend": "4.0.1"
-                            },
-                            "dependencies": {
-                                "errno": {
-                                    "version": "0.1.7",
-                                    "bundled": true,
-                                    "requires": {
-                                        "prr": "1.0.1"
-                                    },
-                                    "dependencies": {
-                                        "prr": {
-                                            "version": "1.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "xtend": {
-                                    "version": "4.0.1",
-                                    "bundled": true
-                                }
-                            }
                         }
+                    }
+                },
+                "libnpmhook": {
+                    "version": "5.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmorg": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmpublish": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "lodash.clonedeep": "^4.5.0",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^4.0.0",
+                        "semver": "^5.5.1",
+                        "ssri": "^6.0.1"
+                    }
+                },
+                "libnpmsearch": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmteam": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "libnpx": {
-                    "version": "9.7.1",
+                    "version": "10.2.0",
                     "bundled": true,
                     "requires": {
-                        "dotenv": "4.0.0",
-                        "npm-package-arg": "5.1.2",
-                        "rimraf": "2.6.2",
-                        "safe-buffer": "5.1.1",
-                        "update-notifier": "2.3.0",
-                        "which": "1.3.0",
-                        "y18n": "3.2.1",
-                        "yargs": "8.0.2"
-                    },
-                    "dependencies": {
-                        "dotenv": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        },
-                        "npm-package-arg": {
-                            "version": "5.1.2",
-                            "bundled": true,
-                            "requires": {
-                                "hosted-git-info": "2.5.0",
-                                "osenv": "0.1.5",
-                                "semver": "5.5.0",
-                                "validate-npm-package-name": "3.0.0"
-                            }
-                        },
-                        "y18n": {
-                            "version": "3.2.1",
-                            "bundled": true
-                        },
-                        "yargs": {
-                            "version": "8.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "camelcase": "4.1.0",
-                                "cliui": "3.2.0",
-                                "decamelize": "1.2.0",
-                                "get-caller-file": "1.0.2",
-                                "os-locale": "2.1.0",
-                                "read-pkg-up": "2.0.0",
-                                "require-directory": "2.1.1",
-                                "require-main-filename": "1.0.1",
-                                "set-blocking": "2.0.0",
-                                "string-width": "2.1.1",
-                                "which-module": "2.0.0",
-                                "y18n": "3.2.1",
-                                "yargs-parser": "7.0.0"
-                            },
-                            "dependencies": {
-                                "camelcase": {
-                                    "version": "4.1.0",
-                                    "bundled": true
-                                },
-                                "cliui": {
-                                    "version": "3.2.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "string-width": "1.0.2",
-                                        "strip-ansi": "3.0.1",
-                                        "wrap-ansi": "2.1.0"
-                                    },
-                                    "dependencies": {
-                                        "string-width": {
-                                            "version": "1.0.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "code-point-at": "1.1.0",
-                                                "is-fullwidth-code-point": "1.0.0",
-                                                "strip-ansi": "3.0.1"
-                                            },
-                                            "dependencies": {
-                                                "code-point-at": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                },
-                                                "is-fullwidth-code-point": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "number-is-nan": "1.0.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "number-is-nan": {
-                                                            "version": "1.0.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "strip-ansi": {
-                                            "version": "3.0.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ansi-regex": "2.1.1"
-                                            },
-                                            "dependencies": {
-                                                "ansi-regex": {
-                                                    "version": "2.1.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "wrap-ansi": {
-                                            "version": "2.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "string-width": "1.0.2",
-                                                "strip-ansi": "3.0.1"
-                                            }
-                                        }
-                                    }
-                                },
-                                "decamelize": {
-                                    "version": "1.2.0",
-                                    "bundled": true
-                                },
-                                "get-caller-file": {
-                                    "version": "1.0.2",
-                                    "bundled": true
-                                },
-                                "os-locale": {
-                                    "version": "2.1.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "execa": "0.7.0",
-                                        "lcid": "1.0.0",
-                                        "mem": "1.1.0"
-                                    },
-                                    "dependencies": {
-                                        "execa": {
-                                            "version": "0.7.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "cross-spawn": "5.1.0",
-                                                "get-stream": "3.0.0",
-                                                "is-stream": "1.1.0",
-                                                "npm-run-path": "2.0.2",
-                                                "p-finally": "1.0.0",
-                                                "signal-exit": "3.0.2",
-                                                "strip-eof": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "cross-spawn": {
-                                                    "version": "5.1.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "lru-cache": "4.1.1",
-                                                        "shebang-command": "1.2.0",
-                                                        "which": "1.3.0"
-                                                    },
-                                                    "dependencies": {
-                                                        "shebang-command": {
-                                                            "version": "1.2.0",
-                                                            "bundled": true,
-                                                            "requires": {
-                                                                "shebang-regex": "1.0.0"
-                                                            },
-                                                            "dependencies": {
-                                                                "shebang-regex": {
-                                                                    "version": "1.0.0",
-                                                                    "bundled": true
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "get-stream": {
-                                                    "version": "3.0.0",
-                                                    "bundled": true
-                                                },
-                                                "is-stream": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                },
-                                                "npm-run-path": {
-                                                    "version": "2.0.2",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "path-key": "2.0.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "path-key": {
-                                                            "version": "2.0.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                },
-                                                "p-finally": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                },
-                                                "signal-exit": {
-                                                    "version": "3.0.2",
-                                                    "bundled": true
-                                                },
-                                                "strip-eof": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "lcid": {
-                                            "version": "1.0.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "invert-kv": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "invert-kv": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "mem": {
-                                            "version": "1.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "mimic-fn": "1.1.0"
-                                            },
-                                            "dependencies": {
-                                                "mimic-fn": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "read-pkg-up": {
-                                    "version": "2.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "find-up": "2.1.0",
-                                        "read-pkg": "2.0.0"
-                                    },
-                                    "dependencies": {
-                                        "find-up": {
-                                            "version": "2.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "locate-path": "2.0.0"
-                                            },
-                                            "dependencies": {
-                                                "locate-path": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "p-locate": "2.0.0",
-                                                        "path-exists": "3.0.0"
-                                                    },
-                                                    "dependencies": {
-                                                        "p-locate": {
-                                                            "version": "2.0.0",
-                                                            "bundled": true,
-                                                            "requires": {
-                                                                "p-limit": "1.1.0"
-                                                            },
-                                                            "dependencies": {
-                                                                "p-limit": {
-                                                                    "version": "1.1.0",
-                                                                    "bundled": true
-                                                                }
-                                                            }
-                                                        },
-                                                        "path-exists": {
-                                                            "version": "3.0.0",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "read-pkg": {
-                                            "version": "2.0.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "load-json-file": "2.0.0",
-                                                "normalize-package-data": "2.4.0",
-                                                "path-type": "2.0.0"
-                                            },
-                                            "dependencies": {
-                                                "load-json-file": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "graceful-fs": "4.1.11",
-                                                        "parse-json": "2.2.0",
-                                                        "pify": "2.3.0",
-                                                        "strip-bom": "3.0.0"
-                                                    },
-                                                    "dependencies": {
-                                                        "parse-json": {
-                                                            "version": "2.2.0",
-                                                            "bundled": true,
-                                                            "requires": {
-                                                                "error-ex": "1.3.1"
-                                                            },
-                                                            "dependencies": {
-                                                                "error-ex": {
-                                                                    "version": "1.3.1",
-                                                                    "bundled": true,
-                                                                    "requires": {
-                                                                        "is-arrayish": "0.2.1"
-                                                                    },
-                                                                    "dependencies": {
-                                                                        "is-arrayish": {
-                                                                            "version": "0.2.1",
-                                                                            "bundled": true
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "pify": {
-                                                            "version": "2.3.0",
-                                                            "bundled": true
-                                                        },
-                                                        "strip-bom": {
-                                                            "version": "3.0.0",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                },
-                                                "path-type": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "pify": "2.3.0"
-                                                    },
-                                                    "dependencies": {
-                                                        "pify": {
-                                                            "version": "2.3.0",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "require-directory": {
-                                    "version": "2.1.1",
-                                    "bundled": true
-                                },
-                                "require-main-filename": {
-                                    "version": "1.0.1",
-                                    "bundled": true
-                                },
-                                "set-blocking": {
-                                    "version": "2.0.0",
-                                    "bundled": true
-                                },
-                                "string-width": {
-                                    "version": "2.1.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-fullwidth-code-point": "2.0.0",
-                                        "strip-ansi": "4.0.0"
-                                    },
-                                    "dependencies": {
-                                        "is-fullwidth-code-point": {
-                                            "version": "2.0.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "which-module": {
-                                    "version": "2.0.0",
-                                    "bundled": true
-                                },
-                                "yargs-parser": {
-                                    "version": "7.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "camelcase": "4.1.0"
-                                    }
-                                }
-                            }
-                        }
+                        "dotenv": "^5.0.1",
+                        "npm-package-arg": "^6.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.3.0",
+                        "which": "^1.3.0",
+                        "y18n": "^4.0.0",
+                        "yargs": "^11.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lock-verify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "npm-package-arg": "^6.1.0",
+                        "semver": "^5.4.1"
                     }
                 },
                 "lockfile": {
-                    "version": "1.0.3",
-                    "bundled": true
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "signal-exit": "^3.0.2"
+                    }
                 },
                 "lodash._baseindexof": {
                     "version": "3.1.0",
@@ -1021,18 +1973,8 @@
                     "version": "4.6.0",
                     "bundled": true,
                     "requires": {
-                        "lodash._createset": "4.0.3",
-                        "lodash._root": "3.0.1"
-                    },
-                    "dependencies": {
-                        "lodash._createset": {
-                            "version": "4.0.3",
-                            "bundled": true
-                        },
-                        "lodash._root": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        }
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
                     }
                 },
                 "lodash._bindcallback": {
@@ -1047,11 +1989,19 @@
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "lodash._getnative": "3.9.1"
+                        "lodash._getnative": "^3.0.0"
                     }
+                },
+                "lodash._createset": {
+                    "version": "4.0.3",
+                    "bundled": true
                 },
                 "lodash._getnative": {
                     "version": "3.9.1",
+                    "bundled": true
+                },
+                "lodash._root": {
+                    "version": "3.0.1",
                     "bundled": true
                 },
                 "lodash.clonedeep": {
@@ -1074,158 +2024,113 @@
                     "version": "4.4.0",
                     "bundled": true
                 },
+                "lowercase-keys": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
                 "lru-cache": {
-                    "version": "4.1.1",
+                    "version": "5.1.1",
                     "bundled": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    },
-                    "dependencies": {
-                        "pseudomap": {
-                            "version": "1.0.2",
-                            "bundled": true
-                        },
-                        "yallist": {
-                            "version": "2.1.2",
-                            "bundled": true
-                        }
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "make-fetch-happen": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "agentkeepalive": "^3.4.1",
+                        "cacache": "^12.0.0",
+                        "http-cache-semantics": "^3.8.1",
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.1",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "node-fetch-npm": "^2.0.2",
+                        "promise-retry": "^1.1.1",
+                        "socks-proxy-agent": "^4.0.0",
+                        "ssri": "^6.0.0"
                     }
                 },
                 "meant": {
                     "version": "1.0.1",
                     "bundled": true
                 },
-                "mississippi": {
-                    "version": "2.0.0",
+                "mem": {
+                    "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.0",
-                        "duplexify": "3.5.3",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.2",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "2.0.1",
-                        "pumpify": "1.4.0",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.35.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.19",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "~1.35.0"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "minipass": {
+                    "version": "2.3.3",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
                     },
                     "dependencies": {
-                        "concat-stream": {
-                            "version": "1.6.0",
-                            "bundled": true,
-                            "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4",
-                                "typedarray": "0.0.6"
-                            },
-                            "dependencies": {
-                                "typedarray": {
-                                    "version": "0.0.6",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "duplexify": {
-                            "version": "3.5.3",
-                            "bundled": true,
-                            "requires": {
-                                "end-of-stream": "1.4.1",
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4",
-                                "stream-shift": "1.0.0"
-                            },
-                            "dependencies": {
-                                "stream-shift": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "end-of-stream": {
-                            "version": "1.4.1",
-                            "bundled": true,
-                            "requires": {
-                                "once": "1.4.0"
-                            }
-                        },
-                        "flush-write-stream": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4"
-                            }
-                        },
-                        "from2": {
-                            "version": "2.3.0",
-                            "bundled": true,
-                            "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4"
-                            }
-                        },
-                        "parallel-transform": {
-                            "version": "1.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "cyclist": "0.2.2",
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4"
-                            },
-                            "dependencies": {
-                                "cyclist": {
-                                    "version": "0.2.2",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "pump": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
-                            }
-                        },
-                        "pumpify": {
-                            "version": "1.4.0",
-                            "bundled": true,
-                            "requires": {
-                                "duplexify": "3.5.3",
-                                "inherits": "2.0.3",
-                                "pump": "2.0.1"
-                            }
-                        },
-                        "stream-each": {
-                            "version": "1.2.2",
-                            "bundled": true,
-                            "requires": {
-                                "end-of-stream": "1.4.1",
-                                "stream-shift": "1.0.0"
-                            },
-                            "dependencies": {
-                                "stream-shift": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "through2": {
-                            "version": "2.0.3",
-                            "bundled": true,
-                            "requires": {
-                                "readable-stream": "2.3.4",
-                                "xtend": "4.0.1"
-                            },
-                            "dependencies": {
-                                "xtend": {
-                                    "version": "4.0.1",
-                                    "bundled": true
-                                }
-                            }
+                        "yallist": {
+                            "version": "3.0.2",
+                            "bundled": true
                         }
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.2",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mississippi": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^3.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "mkdirp": {
@@ -1233,131 +2138,70 @@
                     "bundled": true,
                     "requires": {
                         "minimist": "0.0.8"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "0.0.8",
-                            "bundled": true
-                        }
                     }
                 },
                 "move-concurrently": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "copy-concurrently": "1.0.5",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
                     },
                     "dependencies": {
-                        "copy-concurrently": {
-                            "version": "1.0.5",
-                            "bundled": true,
-                            "requires": {
-                                "aproba": "1.2.0",
-                                "fs-write-stream-atomic": "1.0.10",
-                                "iferr": "0.1.5",
-                                "mkdirp": "0.5.1",
-                                "rimraf": "2.6.2",
-                                "run-queue": "1.0.3"
-                            }
-                        },
-                        "run-queue": {
-                            "version": "1.0.3",
-                            "bundled": true,
-                            "requires": {
-                                "aproba": "1.2.0"
-                            }
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
                         }
                     }
                 },
-                "node-gyp": {
-                    "version": "3.6.2",
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "mute-stream": {
+                    "version": "0.0.7",
+                    "bundled": true
+                },
+                "node-fetch-npm": {
+                    "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "npmlog": "4.1.2",
-                        "osenv": "0.1.5",
-                        "request": "2.83.0",
-                        "rimraf": "2.6.2",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "which": "1.3.0"
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
+                    }
+                },
+                "node-gyp": {
+                    "version": "5.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "env-paths": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "^0.5.0",
+                        "nopt": "2 || 3",
+                        "npmlog": "0 || 1 || 2 || 3 || 4",
+                        "request": "^2.87.0",
+                        "rimraf": "2",
+                        "semver": "~5.3.0",
+                        "tar": "^4.4.12",
+                        "which": "1"
                     },
                     "dependencies": {
-                        "fstream": {
-                            "version": "1.0.11",
-                            "bundled": true,
-                            "requires": {
-                                "graceful-fs": "4.1.11",
-                                "inherits": "2.0.3",
-                                "mkdirp": "0.5.1",
-                                "rimraf": "2.6.2"
-                            }
-                        },
-                        "minimatch": {
-                            "version": "3.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "brace-expansion": "1.1.8"
-                            },
-                            "dependencies": {
-                                "brace-expansion": {
-                                    "version": "1.1.8",
-                                    "bundled": true,
-                                    "requires": {
-                                        "balanced-match": "1.0.0",
-                                        "concat-map": "0.0.1"
-                                    },
-                                    "dependencies": {
-                                        "balanced-match": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        },
-                                        "concat-map": {
-                                            "version": "0.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
                         "nopt": {
                             "version": "3.0.6",
                             "bundled": true,
                             "requires": {
-                                "abbrev": "1.1.1"
+                                "abbrev": "1"
                             }
                         },
                         "semver": {
                             "version": "5.3.0",
                             "bundled": true
-                        },
-                        "tar": {
-                            "version": "2.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "block-stream": "0.0.9",
-                                "fstream": "1.0.11",
-                                "inherits": "2.0.3"
-                            },
-                            "dependencies": {
-                                "block-stream": {
-                                    "version": "0.0.9",
-                                    "bundled": true,
-                                    "requires": {
-                                        "inherits": "2.0.3"
-                                    }
-                                }
-                            }
                         }
                     }
                 },
@@ -1365,558 +2209,123 @@
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "normalize-package-data": {
-                    "version": "2.4.0",
+                    "version": "2.5.0",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.5.0",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.1"
+                        "hosted-git-info": "^2.1.4",
+                        "resolve": "^1.10.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     },
                     "dependencies": {
-                        "is-builtin-module": {
-                            "version": "1.0.0",
+                        "resolve": {
+                            "version": "1.10.0",
                             "bundled": true,
                             "requires": {
-                                "builtin-modules": "1.1.1"
-                            },
-                            "dependencies": {
-                                "builtin-modules": {
-                                    "version": "1.1.1",
-                                    "bundled": true
-                                }
+                                "path-parse": "^1.0.6"
                             }
                         }
                     }
+                },
+                "npm-audit-report": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "cli-table3": "^0.5.0",
+                        "console-control-strings": "^1.1.0"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true
                 },
                 "npm-cache-filename": {
                     "version": "1.0.2",
                     "bundled": true
                 },
                 "npm-install-checks": {
-                    "version": "3.0.0",
+                    "version": "3.0.2",
                     "bundled": true,
                     "requires": {
-                        "semver": "5.5.0"
+                        "semver": "^2.3.0 || 3.x || 4 || 5"
                     }
                 },
                 "npm-lifecycle": {
-                    "version": "2.0.0",
+                    "version": "3.1.4",
                     "bundled": true,
                     "requires": {
-                        "byline": "5.0.0",
-                        "graceful-fs": "4.1.11",
-                        "node-gyp": "3.6.2",
-                        "resolve-from": "4.0.0",
-                        "slide": "1.1.6",
+                        "byline": "^5.0.0",
+                        "graceful-fs": "^4.1.15",
+                        "node-gyp": "^5.0.2",
+                        "resolve-from": "^4.0.0",
+                        "slide": "^1.1.6",
                         "uid-number": "0.0.6",
-                        "umask": "1.1.0",
-                        "which": "1.3.0"
-                    },
-                    "dependencies": {
-                        "byline": {
-                            "version": "5.0.0",
-                            "bundled": true
-                        },
-                        "resolve-from": {
-                            "version": "4.0.0",
-                            "bundled": true
-                        }
+                        "umask": "^1.1.0",
+                        "which": "^1.3.1"
                     }
                 },
+                "npm-logical-tree": {
+                    "version": "1.2.1",
+                    "bundled": true
+                },
                 "npm-package-arg": {
-                    "version": "6.0.0",
+                    "version": "6.1.1",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.5.0",
-                        "osenv": "0.1.5",
-                        "semver": "5.5.0",
-                        "validate-npm-package-name": "3.0.0"
+                        "hosted-git-info": "^2.7.1",
+                        "osenv": "^0.1.5",
+                        "semver": "^5.6.0",
+                        "validate-npm-package-name": "^3.0.0"
                     }
                 },
                 "npm-packlist": {
-                    "version": "1.1.10",
+                    "version": "1.4.4",
                     "bundled": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
-                    },
-                    "dependencies": {
-                        "ignore-walk": {
-                            "version": "3.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "minimatch": "3.0.4"
-                            },
-                            "dependencies": {
-                                "minimatch": {
-                                    "version": "3.0.4",
-                                    "bundled": true,
-                                    "requires": {
-                                        "brace-expansion": "1.1.8"
-                                    },
-                                    "dependencies": {
-                                        "brace-expansion": {
-                                            "version": "1.1.8",
-                                            "bundled": true,
-                                            "requires": {
-                                                "balanced-match": "1.0.0",
-                                                "concat-map": "0.0.1"
-                                            },
-                                            "dependencies": {
-                                                "balanced-match": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                },
-                                                "concat-map": {
-                                                    "version": "0.0.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "npm-bundled": {
-                            "version": "1.0.3",
-                            "bundled": true
-                        }
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npm-pick-manifest": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "npm-package-arg": "^6.0.0",
+                        "semver": "^5.4.1"
                     }
                 },
                 "npm-profile": {
-                    "version": "3.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "make-fetch-happen": "2.6.0"
-                    },
-                    "dependencies": {
-                        "make-fetch-happen": {
-                            "version": "2.6.0",
-                            "bundled": true,
-                            "requires": {
-                                "agentkeepalive": "3.3.0",
-                                "cacache": "10.0.4",
-                                "http-cache-semantics": "3.8.1",
-                                "http-proxy-agent": "2.0.0",
-                                "https-proxy-agent": "2.1.1",
-                                "lru-cache": "4.1.1",
-                                "mississippi": "1.3.1",
-                                "node-fetch-npm": "2.0.2",
-                                "promise-retry": "1.1.1",
-                                "socks-proxy-agent": "3.0.1",
-                                "ssri": "5.2.4"
-                            },
-                            "dependencies": {
-                                "agentkeepalive": {
-                                    "version": "3.3.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "humanize-ms": "1.2.1"
-                                    },
-                                    "dependencies": {
-                                        "humanize-ms": {
-                                            "version": "1.2.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ms": "2.1.1"
-                                            },
-                                            "dependencies": {
-                                                "ms": {
-                                                    "version": "2.1.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "http-cache-semantics": {
-                                    "version": "3.8.1",
-                                    "bundled": true
-                                },
-                                "http-proxy-agent": {
-                                    "version": "2.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "2.6.9"
-                                    },
-                                    "dependencies": {
-                                        "agent-base": {
-                                            "version": "4.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "es6-promisify": "5.0.0"
-                                            },
-                                            "dependencies": {
-                                                "es6-promisify": {
-                                                    "version": "5.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "es6-promise": "4.2.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "es6-promise": {
-                                                            "version": "4.2.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "debug": {
-                                            "version": "2.6.9",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ms": "2.0.0"
-                                            },
-                                            "dependencies": {
-                                                "ms": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "https-proxy-agent": {
-                                    "version": "2.1.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "3.1.0"
-                                    },
-                                    "dependencies": {
-                                        "agent-base": {
-                                            "version": "4.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "es6-promisify": "5.0.0"
-                                            },
-                                            "dependencies": {
-                                                "es6-promisify": {
-                                                    "version": "5.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "es6-promise": "4.2.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "es6-promise": {
-                                                            "version": "4.2.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "debug": {
-                                            "version": "3.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ms": "2.0.0"
-                                            },
-                                            "dependencies": {
-                                                "ms": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "mississippi": {
-                                    "version": "1.3.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "concat-stream": "1.6.0",
-                                        "duplexify": "3.5.3",
-                                        "end-of-stream": "1.4.1",
-                                        "flush-write-stream": "1.0.2",
-                                        "from2": "2.3.0",
-                                        "parallel-transform": "1.1.0",
-                                        "pump": "1.0.3",
-                                        "pumpify": "1.4.0",
-                                        "stream-each": "1.2.2",
-                                        "through2": "2.0.3"
-                                    },
-                                    "dependencies": {
-                                        "concat-stream": {
-                                            "version": "1.6.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "typedarray": "0.0.6"
-                                            },
-                                            "dependencies": {
-                                                "typedarray": {
-                                                    "version": "0.0.6",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "duplexify": {
-                                            "version": "3.5.3",
-                                            "bundled": true,
-                                            "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "stream-shift": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "stream-shift": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "end-of-stream": {
-                                            "version": "1.4.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "once": "1.4.0"
-                                            }
-                                        },
-                                        "flush-write-stream": {
-                                            "version": "1.0.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
-                                            }
-                                        },
-                                        "from2": {
-                                            "version": "2.3.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
-                                            }
-                                        },
-                                        "parallel-transform": {
-                                            "version": "1.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "cyclist": "0.2.2",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
-                                            },
-                                            "dependencies": {
-                                                "cyclist": {
-                                                    "version": "0.2.2",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "pump": {
-                                            "version": "1.0.3",
-                                            "bundled": true,
-                                            "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "once": "1.4.0"
-                                            }
-                                        },
-                                        "pumpify": {
-                                            "version": "1.4.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "duplexify": "3.5.3",
-                                                "inherits": "2.0.3",
-                                                "pump": "2.0.1"
-                                            },
-                                            "dependencies": {
-                                                "pump": {
-                                                    "version": "2.0.1",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "end-of-stream": "1.4.1",
-                                                        "once": "1.4.0"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "stream-each": {
-                                            "version": "1.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "stream-shift": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "stream-shift": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "through2": {
-                                            "version": "2.0.3",
-                                            "bundled": true,
-                                            "requires": {
-                                                "readable-stream": "2.3.4",
-                                                "xtend": "4.0.1"
-                                            },
-                                            "dependencies": {
-                                                "xtend": {
-                                                    "version": "4.0.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "node-fetch-npm": {
-                                    "version": "2.0.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "encoding": "0.1.12",
-                                        "json-parse-better-errors": "1.0.1",
-                                        "safe-buffer": "5.1.1"
-                                    },
-                                    "dependencies": {
-                                        "encoding": {
-                                            "version": "0.1.12",
-                                            "bundled": true,
-                                            "requires": {
-                                                "iconv-lite": "0.4.19"
-                                            },
-                                            "dependencies": {
-                                                "iconv-lite": {
-                                                    "version": "0.4.19",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "json-parse-better-errors": {
-                                            "version": "1.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "promise-retry": {
-                                    "version": "1.1.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "err-code": "1.1.2",
-                                        "retry": "0.10.1"
-                                    },
-                                    "dependencies": {
-                                        "err-code": {
-                                            "version": "1.1.2",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "socks-proxy-agent": {
-                                    "version": "3.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "agent-base": "4.2.0",
-                                        "socks": "1.1.10"
-                                    },
-                                    "dependencies": {
-                                        "agent-base": {
-                                            "version": "4.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "es6-promisify": "5.0.0"
-                                            },
-                                            "dependencies": {
-                                                "es6-promisify": {
-                                                    "version": "5.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "es6-promise": "4.2.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "es6-promise": {
-                                                            "version": "4.2.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "socks": {
-                                            "version": "1.1.10",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ip": "1.1.5",
-                                                "smart-buffer": "1.1.15"
-                                            },
-                                            "dependencies": {
-                                                "ip": {
-                                                    "version": "1.1.5",
-                                                    "bundled": true
-                                                },
-                                                "smart-buffer": {
-                                                    "version": "1.1.15",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        "aproba": "^1.1.2 || 2",
+                        "figgy-pudding": "^3.4.1",
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
-                "npm-registry-client": {
-                    "version": "8.5.0",
+                "npm-registry-fetch": {
+                    "version": "4.0.0",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.0",
-                        "graceful-fs": "4.1.11",
-                        "normalize-package-data": "2.4.0",
-                        "npm-package-arg": "5.1.2",
-                        "npmlog": "4.1.2",
-                        "once": "1.4.0",
-                        "request": "2.83.0",
-                        "retry": "0.10.1",
-                        "semver": "5.5.0",
-                        "slide": "1.1.6",
-                        "ssri": "4.1.6"
-                    },
-                    "dependencies": {
-                        "concat-stream": {
-                            "version": "1.6.0",
-                            "bundled": true,
-                            "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.3.4",
-                                "typedarray": "0.0.6"
-                            },
-                            "dependencies": {
-                                "typedarray": {
-                                    "version": "0.0.6",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "npm-package-arg": {
-                            "version": "5.1.2",
-                            "bundled": true,
-                            "requires": {
-                                "hosted-git-info": "2.5.0",
-                                "osenv": "0.1.5",
-                                "semver": "5.5.0",
-                                "validate-npm-package-name": "3.0.0"
-                            }
-                        },
-                        "ssri": {
-                            "version": "4.1.6",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "5.1.1"
-                            }
-                        }
+                        "JSONStream": "^1.3.4",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.4.1",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
+                        "npm-package-arg": "^6.1.0"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
                     }
                 },
                 "npm-user-validate": {
@@ -1927,1258 +2336,556 @@
                     "version": "4.1.2",
                     "bundled": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
-                    },
-                    "dependencies": {
-                        "are-we-there-yet": {
-                            "version": "1.1.4",
-                            "bundled": true,
-                            "requires": {
-                                "delegates": "1.0.0",
-                                "readable-stream": "2.3.4"
-                            },
-                            "dependencies": {
-                                "delegates": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "console-control-strings": {
-                            "version": "1.1.0",
-                            "bundled": true
-                        },
-                        "gauge": {
-                            "version": "2.7.4",
-                            "bundled": true,
-                            "requires": {
-                                "aproba": "1.2.0",
-                                "console-control-strings": "1.1.0",
-                                "has-unicode": "2.0.1",
-                                "object-assign": "4.1.1",
-                                "signal-exit": "3.0.2",
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wide-align": "1.1.2"
-                            },
-                            "dependencies": {
-                                "object-assign": {
-                                    "version": "4.1.1",
-                                    "bundled": true
-                                },
-                                "signal-exit": {
-                                    "version": "3.0.2",
-                                    "bundled": true
-                                },
-                                "string-width": {
-                                    "version": "1.0.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "code-point-at": "1.1.0",
-                                        "is-fullwidth-code-point": "1.0.0",
-                                        "strip-ansi": "3.0.1"
-                                    },
-                                    "dependencies": {
-                                        "code-point-at": {
-                                            "version": "1.1.0",
-                                            "bundled": true
-                                        },
-                                        "is-fullwidth-code-point": {
-                                            "version": "1.0.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "number-is-nan": "1.0.1"
-                                            },
-                                            "dependencies": {
-                                                "number-is-nan": {
-                                                    "version": "1.0.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "strip-ansi": {
-                                    "version": "3.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "ansi-regex": "2.1.1"
-                                    },
-                                    "dependencies": {
-                                        "ansi-regex": {
-                                            "version": "2.1.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "wide-align": {
-                                    "version": "1.1.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "string-width": "1.0.2"
-                                    }
-                                }
-                            }
-                        },
-                        "set-blocking": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        }
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "bundled": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true
+                },
+                "object-keys": {
+                    "version": "1.0.12",
+                    "bundled": true
+                },
+                "object.getownpropertydescriptors": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "define-properties": "^1.1.2",
+                        "es-abstract": "^1.5.1"
                     }
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "opener": {
-                    "version": "1.4.3",
+                    "version": "1.5.1",
+                    "bundled": true
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
                     "bundled": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "bundled": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
-                    },
-                    "dependencies": {
-                        "os-homedir": {
-                            "version": "1.0.2",
-                            "bundled": true
-                        },
-                        "os-tmpdir": {
-                            "version": "1.0.2",
-                            "bundled": true
-                        }
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "p-limit": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "package-json": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
                     }
                 },
                 "pacote": {
-                    "version": "7.3.3",
+                    "version": "9.5.8",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "cacache": "10.0.4",
-                        "get-stream": "3.0.0",
-                        "glob": "7.1.2",
-                        "lru-cache": "4.1.1",
-                        "make-fetch-happen": "2.6.0",
-                        "minimatch": "3.0.4",
-                        "mississippi": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "npm-package-arg": "6.0.0",
-                        "npm-packlist": "1.1.10",
-                        "npm-pick-manifest": "2.1.0",
-                        "osenv": "0.1.5",
-                        "promise-inflight": "1.0.1",
-                        "promise-retry": "1.1.1",
-                        "protoduck": "5.0.0",
-                        "safe-buffer": "5.1.1",
-                        "semver": "5.5.0",
-                        "ssri": "5.2.4",
-                        "tar": "4.3.3",
-                        "unique-filename": "1.1.0",
-                        "which": "1.3.0"
+                        "bluebird": "^3.5.3",
+                        "cacache": "^12.0.2",
+                        "chownr": "^1.1.2",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.1.0",
+                        "glob": "^7.1.3",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
+                        "minimatch": "^3.0.4",
+                        "minipass": "^2.3.5",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-packlist": "^1.1.12",
+                        "npm-pick-manifest": "^3.0.0",
+                        "npm-registry-fetch": "^4.0.0",
+                        "osenv": "^0.1.5",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^1.1.1",
+                        "protoduck": "^5.0.1",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.2",
+                        "semver": "^5.6.0",
+                        "ssri": "^6.0.1",
+                        "tar": "^4.4.10",
+                        "unique-filename": "^1.1.1",
+                        "which": "^1.3.1"
                     },
                     "dependencies": {
-                        "get-stream": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        },
-                        "make-fetch-happen": {
-                            "version": "2.6.0",
+                        "minipass": {
+                            "version": "2.3.5",
                             "bundled": true,
                             "requires": {
-                                "agentkeepalive": "3.3.0",
-                                "cacache": "10.0.4",
-                                "http-cache-semantics": "3.8.1",
-                                "http-proxy-agent": "2.0.0",
-                                "https-proxy-agent": "2.1.1",
-                                "lru-cache": "4.1.1",
-                                "mississippi": "1.3.1",
-                                "node-fetch-npm": "2.0.2",
-                                "promise-retry": "1.1.1",
-                                "socks-proxy-agent": "3.0.1",
-                                "ssri": "5.2.4"
-                            },
-                            "dependencies": {
-                                "agentkeepalive": {
-                                    "version": "3.3.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "humanize-ms": "1.2.1"
-                                    },
-                                    "dependencies": {
-                                        "humanize-ms": {
-                                            "version": "1.2.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ms": "2.1.1"
-                                            },
-                                            "dependencies": {
-                                                "ms": {
-                                                    "version": "2.1.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "http-cache-semantics": {
-                                    "version": "3.8.1",
-                                    "bundled": true
-                                },
-                                "http-proxy-agent": {
-                                    "version": "2.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "2.6.9"
-                                    },
-                                    "dependencies": {
-                                        "agent-base": {
-                                            "version": "4.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "es6-promisify": "5.0.0"
-                                            },
-                                            "dependencies": {
-                                                "es6-promisify": {
-                                                    "version": "5.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "es6-promise": "4.2.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "es6-promise": {
-                                                            "version": "4.2.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "debug": {
-                                            "version": "2.6.9",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ms": "2.0.0"
-                                            },
-                                            "dependencies": {
-                                                "ms": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "https-proxy-agent": {
-                                    "version": "2.1.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "agent-base": "4.2.0",
-                                        "debug": "3.1.0"
-                                    },
-                                    "dependencies": {
-                                        "agent-base": {
-                                            "version": "4.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "es6-promisify": "5.0.0"
-                                            },
-                                            "dependencies": {
-                                                "es6-promisify": {
-                                                    "version": "5.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "es6-promise": "4.2.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "es6-promise": {
-                                                            "version": "4.2.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "debug": {
-                                            "version": "3.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ms": "2.0.0"
-                                            },
-                                            "dependencies": {
-                                                "ms": {
-                                                    "version": "2.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "mississippi": {
-                                    "version": "1.3.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "concat-stream": "1.6.0",
-                                        "duplexify": "3.5.3",
-                                        "end-of-stream": "1.4.1",
-                                        "flush-write-stream": "1.0.2",
-                                        "from2": "2.3.0",
-                                        "parallel-transform": "1.1.0",
-                                        "pump": "1.0.3",
-                                        "pumpify": "1.4.0",
-                                        "stream-each": "1.2.2",
-                                        "through2": "2.0.3"
-                                    },
-                                    "dependencies": {
-                                        "concat-stream": {
-                                            "version": "1.6.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "typedarray": "0.0.6"
-                                            },
-                                            "dependencies": {
-                                                "typedarray": {
-                                                    "version": "0.0.6",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "duplexify": {
-                                            "version": "3.5.3",
-                                            "bundled": true,
-                                            "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4",
-                                                "stream-shift": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "stream-shift": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "end-of-stream": {
-                                            "version": "1.4.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "once": "1.4.0"
-                                            }
-                                        },
-                                        "flush-write-stream": {
-                                            "version": "1.0.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
-                                            }
-                                        },
-                                        "from2": {
-                                            "version": "2.3.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
-                                            }
-                                        },
-                                        "parallel-transform": {
-                                            "version": "1.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "cyclist": "0.2.2",
-                                                "inherits": "2.0.3",
-                                                "readable-stream": "2.3.4"
-                                            },
-                                            "dependencies": {
-                                                "cyclist": {
-                                                    "version": "0.2.2",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "pump": {
-                                            "version": "1.0.3",
-                                            "bundled": true,
-                                            "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "once": "1.4.0"
-                                            }
-                                        },
-                                        "pumpify": {
-                                            "version": "1.4.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "duplexify": "3.5.3",
-                                                "inherits": "2.0.3",
-                                                "pump": "2.0.1"
-                                            },
-                                            "dependencies": {
-                                                "pump": {
-                                                    "version": "2.0.1",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "end-of-stream": "1.4.1",
-                                                        "once": "1.4.0"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "stream-each": {
-                                            "version": "1.2.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "end-of-stream": "1.4.1",
-                                                "stream-shift": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "stream-shift": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "through2": {
-                                            "version": "2.0.3",
-                                            "bundled": true,
-                                            "requires": {
-                                                "readable-stream": "2.3.4",
-                                                "xtend": "4.0.1"
-                                            },
-                                            "dependencies": {
-                                                "xtend": {
-                                                    "version": "4.0.1",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "node-fetch-npm": {
-                                    "version": "2.0.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "encoding": "0.1.12",
-                                        "json-parse-better-errors": "1.0.1",
-                                        "safe-buffer": "5.1.1"
-                                    },
-                                    "dependencies": {
-                                        "encoding": {
-                                            "version": "0.1.12",
-                                            "bundled": true,
-                                            "requires": {
-                                                "iconv-lite": "0.4.19"
-                                            },
-                                            "dependencies": {
-                                                "iconv-lite": {
-                                                    "version": "0.4.19",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        },
-                                        "json-parse-better-errors": {
-                                            "version": "1.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "socks-proxy-agent": {
-                                    "version": "3.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "agent-base": "4.2.0",
-                                        "socks": "1.1.10"
-                                    },
-                                    "dependencies": {
-                                        "agent-base": {
-                                            "version": "4.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "es6-promisify": "5.0.0"
-                                            },
-                                            "dependencies": {
-                                                "es6-promisify": {
-                                                    "version": "5.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "es6-promise": "4.2.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "es6-promise": {
-                                                            "version": "4.2.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "socks": {
-                                            "version": "1.1.10",
-                                            "bundled": true,
-                                            "requires": {
-                                                "ip": "1.1.5",
-                                                "smart-buffer": "1.1.15"
-                                            },
-                                            "dependencies": {
-                                                "ip": {
-                                                    "version": "1.1.5",
-                                                    "bundled": true
-                                                },
-                                                "smart-buffer": {
-                                                    "version": "1.1.15",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
                             }
-                        },
-                        "minimatch": {
-                            "version": "3.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "brace-expansion": "1.1.11"
-                            },
-                            "dependencies": {
-                                "brace-expansion": {
-                                    "version": "1.1.11",
-                                    "bundled": true,
-                                    "requires": {
-                                        "balanced-match": "1.0.0",
-                                        "concat-map": "0.0.1"
-                                    },
-                                    "dependencies": {
-                                        "balanced-match": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        },
-                                        "concat-map": {
-                                            "version": "0.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "mississippi": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "concat-stream": "1.6.0",
-                                "duplexify": "3.5.3",
-                                "end-of-stream": "1.4.1",
-                                "flush-write-stream": "1.0.2",
-                                "from2": "2.3.0",
-                                "parallel-transform": "1.1.0",
-                                "pump": "2.0.1",
-                                "pumpify": "1.4.0",
-                                "stream-each": "1.2.2",
-                                "through2": "2.0.3"
-                            },
-                            "dependencies": {
-                                "concat-stream": {
-                                    "version": "1.6.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4",
-                                        "typedarray": "0.0.6"
-                                    },
-                                    "dependencies": {
-                                        "typedarray": {
-                                            "version": "0.0.6",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "duplexify": {
-                                    "version": "3.5.3",
-                                    "bundled": true,
-                                    "requires": {
-                                        "end-of-stream": "1.4.1",
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4",
-                                        "stream-shift": "1.0.0"
-                                    },
-                                    "dependencies": {
-                                        "stream-shift": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "end-of-stream": {
-                                    "version": "1.4.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "once": "1.4.0"
-                                    }
-                                },
-                                "flush-write-stream": {
-                                    "version": "1.0.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4"
-                                    }
-                                },
-                                "from2": {
-                                    "version": "2.3.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4"
-                                    }
-                                },
-                                "parallel-transform": {
-                                    "version": "1.1.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "cyclist": "0.2.2",
-                                        "inherits": "2.0.3",
-                                        "readable-stream": "2.3.4"
-                                    },
-                                    "dependencies": {
-                                        "cyclist": {
-                                            "version": "0.2.2",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "pump": {
-                                    "version": "2.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "end-of-stream": "1.4.1",
-                                        "once": "1.4.0"
-                                    }
-                                },
-                                "pumpify": {
-                                    "version": "1.4.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "duplexify": "3.5.3",
-                                        "inherits": "2.0.3",
-                                        "pump": "2.0.1"
-                                    }
-                                },
-                                "stream-each": {
-                                    "version": "1.2.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "end-of-stream": "1.4.1",
-                                        "stream-shift": "1.0.0"
-                                    },
-                                    "dependencies": {
-                                        "stream-shift": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "through2": {
-                                    "version": "2.0.3",
-                                    "bundled": true,
-                                    "requires": {
-                                        "readable-stream": "2.3.4",
-                                        "xtend": "4.0.1"
-                                    },
-                                    "dependencies": {
-                                        "xtend": {
-                                            "version": "4.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "npm-pick-manifest": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "npm-package-arg": "6.0.0",
-                                "semver": "5.5.0"
-                            }
-                        },
-                        "promise-retry": {
-                            "version": "1.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "err-code": "1.1.2",
-                                "retry": "0.10.1"
-                            },
-                            "dependencies": {
-                                "err-code": {
-                                    "version": "1.1.2",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "protoduck": {
-                            "version": "5.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "genfun": "4.0.1"
-                            },
-                            "dependencies": {
-                                "genfun": {
-                                    "version": "4.0.1",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "semver": {
-                            "version": "5.5.0",
-                            "bundled": true
                         }
                     }
                 },
+                "parallel-transform": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
                 "path-is-inside": {
                     "version": "1.0.2",
+                    "bundled": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "bundled": true
+                },
+                "performance-now": {
+                    "version": "2.1.0",
+                    "bundled": true
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "promise-inflight": {
                     "version": "1.0.1",
                     "bundled": true
                 },
+                "promise-retry": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "err-code": "^1.0.0",
+                        "retry": "^0.10.0"
+                    },
+                    "dependencies": {
+                        "retry": {
+                            "version": "0.10.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "promzard": {
+                    "version": "0.3.0",
+                    "bundled": true,
+                    "requires": {
+                        "read": "1"
+                    }
+                },
+                "proto-list": {
+                    "version": "1.2.4",
+                    "bundled": true
+                },
+                "protoduck": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "genfun": "^5.0.0"
+                    }
+                },
+                "prr": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "psl": {
+                    "version": "1.1.29",
+                    "bundled": true
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "pumpify": {
+                    "version": "1.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "duplexify": "^3.6.0",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pump": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
+                            }
+                        }
+                    }
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true
+                },
                 "qrcode-terminal": {
-                    "version": "0.11.0",
+                    "version": "0.12.0",
+                    "bundled": true
+                },
+                "qs": {
+                    "version": "6.5.2",
                     "bundled": true
                 },
                 "query-string": {
-                    "version": "5.1.0",
+                    "version": "6.8.2",
                     "bundled": true,
                     "requires": {
-                        "decode-uri-component": "0.2.0",
-                        "object-assign": "4.1.1",
-                        "strict-uri-encode": "1.1.0"
-                    },
-                    "dependencies": {
-                        "decode-uri-component": {
-                            "version": "0.2.0",
-                            "bundled": true
-                        },
-                        "object-assign": {
-                            "version": "4.1.1",
-                            "bundled": true
-                        },
-                        "strict-uri-encode": {
-                            "version": "1.1.0",
-                            "bundled": true
-                        }
+                        "decode-uri-component": "^0.2.0",
+                        "split-on-first": "^1.0.0",
+                        "strict-uri-encode": "^2.0.0"
                     }
                 },
                 "qw": {
                     "version": "1.0.1",
                     "bundled": true
                 },
-                "read": {
-                    "version": "1.0.7",
+                "rc": {
+                    "version": "1.2.7",
                     "bundled": true,
                     "requires": {
-                        "mute-stream": "0.0.7"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
-                        "mute-stream": {
-                            "version": "0.0.7",
+                        "minimist": {
+                            "version": "1.2.0",
                             "bundled": true
                         }
                     }
                 },
-                "read-cmd-shim": {
-                    "version": "1.0.1",
+                "read": {
+                    "version": "1.0.7",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "mute-stream": "~0.0.4"
+                    }
+                },
+                "read-cmd-shim": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "read-installed": {
                     "version": "4.0.3",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "graceful-fs": "4.1.11",
-                        "read-package-json": "2.0.12",
-                        "readdir-scoped-modules": "1.0.2",
-                        "semver": "5.5.0",
-                        "slide": "1.1.6",
-                        "util-extend": "1.0.3"
-                    },
-                    "dependencies": {
-                        "util-extend": {
-                            "version": "1.0.3",
-                            "bundled": true
-                        }
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
                     }
                 },
                 "read-package-json": {
-                    "version": "2.0.12",
+                    "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "json-parse-better-errors": "1.0.1",
-                        "normalize-package-data": "2.4.0",
-                        "slash": "1.0.0"
-                    },
-                    "dependencies": {
-                        "json-parse-better-errors": {
-                            "version": "1.0.1",
-                            "bundled": true
-                        },
-                        "slash": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        }
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-better-errors": "^1.0.1",
+                        "normalize-package-data": "^2.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "read-package-tree": {
-                    "version": "5.1.6",
+                    "version": "5.3.1",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "once": "1.4.0",
-                        "read-package-json": "2.0.12",
-                        "readdir-scoped-modules": "1.0.2"
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "util-promisify": "^2.1.0"
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.4",
+                    "version": "3.4.0",
                     "bundled": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
-                    },
-                    "dependencies": {
-                        "core-util-is": {
-                            "version": "1.0.2",
-                            "bundled": true
-                        },
-                        "isarray": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "process-nextick-args": {
-                            "version": "2.0.0",
-                            "bundled": true
-                        },
-                        "string_decoder": {
-                            "version": "1.0.3",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "5.1.1"
-                            }
-                        },
-                        "util-deprecate": {
-                            "version": "1.0.2",
-                            "bundled": true
-                        }
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 },
                 "readdir-scoped-modules": {
-                    "version": "1.0.2",
+                    "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "graceful-fs": "4.1.11",
-                        "once": "1.4.0"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
+                    }
+                },
+                "registry-auth-token": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "registry-url": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "rc": "^1.0.1"
                     }
                 },
                 "request": {
-                    "version": "2.83.0",
+                    "version": "2.88.0",
                     "bundled": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.1",
-                        "har-validator": "5.0.3",
-                        "hawk": "6.0.2",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.1",
-                        "safe-buffer": "5.1.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.2.1"
-                    },
-                    "dependencies": {
-                        "aws-sign2": {
-                            "version": "0.7.0",
-                            "bundled": true
-                        },
-                        "aws4": {
-                            "version": "1.6.0",
-                            "bundled": true
-                        },
-                        "caseless": {
-                            "version": "0.12.0",
-                            "bundled": true
-                        },
-                        "combined-stream": {
-                            "version": "1.0.5",
-                            "bundled": true,
-                            "requires": {
-                                "delayed-stream": "1.0.0"
-                            },
-                            "dependencies": {
-                                "delayed-stream": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "extend": {
-                            "version": "3.0.1",
-                            "bundled": true
-                        },
-                        "forever-agent": {
-                            "version": "0.6.1",
-                            "bundled": true
-                        },
-                        "form-data": {
-                            "version": "2.3.1",
-                            "bundled": true,
-                            "requires": {
-                                "asynckit": "0.4.0",
-                                "combined-stream": "1.0.5",
-                                "mime-types": "2.1.17"
-                            },
-                            "dependencies": {
-                                "asynckit": {
-                                    "version": "0.4.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "har-validator": {
-                            "version": "5.0.3",
-                            "bundled": true,
-                            "requires": {
-                                "ajv": "5.2.3",
-                                "har-schema": "2.0.0"
-                            },
-                            "dependencies": {
-                                "ajv": {
-                                    "version": "5.2.3",
-                                    "bundled": true,
-                                    "requires": {
-                                        "co": "4.6.0",
-                                        "fast-deep-equal": "1.0.0",
-                                        "json-schema-traverse": "0.3.1",
-                                        "json-stable-stringify": "1.0.1"
-                                    },
-                                    "dependencies": {
-                                        "co": {
-                                            "version": "4.6.0",
-                                            "bundled": true
-                                        },
-                                        "fast-deep-equal": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        },
-                                        "json-schema-traverse": {
-                                            "version": "0.3.1",
-                                            "bundled": true
-                                        },
-                                        "json-stable-stringify": {
-                                            "version": "1.0.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "jsonify": "0.0.0"
-                                            },
-                                            "dependencies": {
-                                                "jsonify": {
-                                                    "version": "0.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "har-schema": {
-                                    "version": "2.0.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "hawk": {
-                            "version": "6.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "boom": "4.3.1",
-                                "cryptiles": "3.1.2",
-                                "hoek": "4.2.0",
-                                "sntp": "2.0.2"
-                            },
-                            "dependencies": {
-                                "boom": {
-                                    "version": "4.3.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "hoek": "4.2.0"
-                                    }
-                                },
-                                "cryptiles": {
-                                    "version": "3.1.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "boom": "5.2.0"
-                                    },
-                                    "dependencies": {
-                                        "boom": {
-                                            "version": "5.2.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "hoek": "4.2.0"
-                                            }
-                                        }
-                                    }
-                                },
-                                "hoek": {
-                                    "version": "4.2.0",
-                                    "bundled": true
-                                },
-                                "sntp": {
-                                    "version": "2.0.2",
-                                    "bundled": true,
-                                    "requires": {
-                                        "hoek": "4.2.0"
-                                    }
-                                }
-                            }
-                        },
-                        "http-signature": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "requires": {
-                                "assert-plus": "1.0.0",
-                                "jsprim": "1.4.1",
-                                "sshpk": "1.13.1"
-                            },
-                            "dependencies": {
-                                "assert-plus": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                },
-                                "jsprim": {
-                                    "version": "1.4.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "assert-plus": "1.0.0",
-                                        "extsprintf": "1.3.0",
-                                        "json-schema": "0.2.3",
-                                        "verror": "1.10.0"
-                                    },
-                                    "dependencies": {
-                                        "extsprintf": {
-                                            "version": "1.3.0",
-                                            "bundled": true
-                                        },
-                                        "json-schema": {
-                                            "version": "0.2.3",
-                                            "bundled": true
-                                        },
-                                        "verror": {
-                                            "version": "1.10.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "assert-plus": "1.0.0",
-                                                "core-util-is": "1.0.2",
-                                                "extsprintf": "1.3.0"
-                                            },
-                                            "dependencies": {
-                                                "core-util-is": {
-                                                    "version": "1.0.2",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "sshpk": {
-                                    "version": "1.13.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "asn1": "0.2.3",
-                                        "assert-plus": "1.0.0",
-                                        "bcrypt-pbkdf": "1.0.1",
-                                        "dashdash": "1.14.1",
-                                        "ecc-jsbn": "0.1.1",
-                                        "getpass": "0.1.7",
-                                        "jsbn": "0.1.1",
-                                        "tweetnacl": "0.14.5"
-                                    },
-                                    "dependencies": {
-                                        "asn1": {
-                                            "version": "0.2.3",
-                                            "bundled": true
-                                        },
-                                        "bcrypt-pbkdf": {
-                                            "version": "1.0.1",
-                                            "bundled": true,
-                                            "optional": true,
-                                            "requires": {
-                                                "tweetnacl": "0.14.5"
-                                            }
-                                        },
-                                        "dashdash": {
-                                            "version": "1.14.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "assert-plus": "1.0.0"
-                                            }
-                                        },
-                                        "ecc-jsbn": {
-                                            "version": "0.1.1",
-                                            "bundled": true,
-                                            "optional": true,
-                                            "requires": {
-                                                "jsbn": "0.1.1"
-                                            }
-                                        },
-                                        "getpass": {
-                                            "version": "0.1.7",
-                                            "bundled": true,
-                                            "requires": {
-                                                "assert-plus": "1.0.0"
-                                            }
-                                        },
-                                        "jsbn": {
-                                            "version": "0.1.1",
-                                            "bundled": true,
-                                            "optional": true
-                                        },
-                                        "tweetnacl": {
-                                            "version": "0.14.5",
-                                            "bundled": true,
-                                            "optional": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "is-typedarray": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "isstream": {
-                            "version": "0.1.2",
-                            "bundled": true
-                        },
-                        "json-stringify-safe": {
-                            "version": "5.0.1",
-                            "bundled": true
-                        },
-                        "mime-types": {
-                            "version": "2.1.17",
-                            "bundled": true,
-                            "requires": {
-                                "mime-db": "1.30.0"
-                            },
-                            "dependencies": {
-                                "mime-db": {
-                                    "version": "1.30.0",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "oauth-sign": {
-                            "version": "0.8.2",
-                            "bundled": true
-                        },
-                        "performance-now": {
-                            "version": "2.1.0",
-                            "bundled": true
-                        },
-                        "qs": {
-                            "version": "6.5.1",
-                            "bundled": true
-                        },
-                        "stringstream": {
-                            "version": "0.0.5",
-                            "bundled": true
-                        },
-                        "tough-cookie": {
-                            "version": "2.3.3",
-                            "bundled": true,
-                            "requires": {
-                                "punycode": "1.4.1"
-                            },
-                            "dependencies": {
-                                "punycode": {
-                                    "version": "1.4.1",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "tunnel-agent": {
-                            "version": "0.6.0",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "5.1.1"
-                            }
-                        }
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true
+                },
                 "retry": {
-                    "version": "0.10.1",
+                    "version": "0.12.0",
                     "bundled": true
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.1.3"
+                    }
+                },
+                "run-queue": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.1",
+                    "version": "5.1.2",
+                    "bundled": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
                     "bundled": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.7.1",
+                    "bundled": true
+                },
+                "semver-diff": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "semver": "^5.0.3"
+                    }
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "sha": {
-                    "version": "2.0.1",
+                    "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "readable-stream": "2.3.4"
+                        "graceful-fs": "^4.1.2"
                     }
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "bundled": true
                 },
                 "slide": {
                     "version": "1.1.6",
                     "bundled": true
+                },
+                "smart-buffer": {
+                    "version": "4.0.2",
+                    "bundled": true
+                },
+                "socks": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "requires": {
+                        "ip": "^1.1.5",
+                        "smart-buffer": "4.0.2"
+                    }
+                },
+                "socks-proxy-agent": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "agent-base": "~4.2.1",
+                        "socks": "~2.3.2"
+                    },
+                    "dependencies": {
+                        "agent-base": {
+                            "version": "4.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "es6-promisify": "^5.0.0"
+                            }
+                        }
+                    }
                 },
                 "sorted-object": {
                     "version": "2.0.1",
@@ -3188,121 +2895,290 @@
                     "version": "2.1.3",
                     "bundled": true,
                     "requires": {
-                        "from2": "1.3.0",
-                        "stream-iterate": "1.2.0"
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
                     },
                     "dependencies": {
                         "from2": {
                             "version": "1.3.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "1.1.14"
-                            },
-                            "dependencies": {
-                                "readable-stream": {
-                                    "version": "1.1.14",
-                                    "bundled": true,
-                                    "requires": {
-                                        "core-util-is": "1.0.2",
-                                        "inherits": "2.0.3",
-                                        "isarray": "0.0.1",
-                                        "string_decoder": "0.10.31"
-                                    },
-                                    "dependencies": {
-                                        "core-util-is": {
-                                            "version": "1.0.2",
-                                            "bundled": true
-                                        },
-                                        "isarray": {
-                                            "version": "0.0.1",
-                                            "bundled": true
-                                        },
-                                        "string_decoder": {
-                                            "version": "0.10.31",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
                             }
                         },
-                        "stream-iterate": {
-                            "version": "1.2.0",
+                        "isarray": {
+                            "version": "0.0.1",
+                            "bundled": true
+                        },
+                        "readable-stream": {
+                            "version": "1.1.14",
                             "bundled": true,
                             "requires": {
-                                "readable-stream": "2.3.4",
-                                "stream-shift": "1.0.0"
-                            },
-                            "dependencies": {
-                                "stream-shift": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                }
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "0.0.1",
+                                "string_decoder": "~0.10.x"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "0.10.31",
+                            "bundled": true
+                        }
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "bundled": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.3",
+                    "bundled": true
+                },
+                "split-on-first": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "sshpk": {
+                    "version": "1.14.2",
+                    "bundled": true,
+                    "requires": {
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.0.2",
+                        "tweetnacl": "~0.14.0"
+                    }
+                },
+                "ssri": {
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1"
+                    }
+                },
+                "stream-each": {
+                    "version": "1.2.2",
+                    "bundled": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
+                    }
+                },
+                "stream-iterate": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "stream-shift": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
                             }
                         }
                     }
                 },
-                "ssri": {
-                    "version": "5.2.4",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
+                "stream-shift": {
+                    "version": "1.0.0",
+                    "bundled": true
                 },
-                "strip-ansi": {
-                    "version": "4.0.0",
+                "strict-uri-encode": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
                             "version": "3.0.0",
                             "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
                         }
                     }
                 },
-                "tar": {
-                    "version": "4.3.3",
+                "string_decoder": {
+                    "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.1",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "stringify-package": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "4.4.12",
+                    "bundled": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.8.6",
+                        "minizlib": "^1.2.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.3"
                     },
                     "dependencies": {
-                        "fs-minipass": {
-                            "version": "1.2.5",
-                            "bundled": true,
-                            "requires": {
-                                "minipass": "2.2.1"
-                            }
-                        },
                         "minipass": {
-                            "version": "2.2.1",
+                            "version": "2.8.6",
                             "bundled": true,
                             "requires": {
-                                "yallist": "3.0.2"
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
                             }
-                        },
-                        "minizlib": {
-                            "version": "1.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "minipass": "2.2.1"
-                            }
-                        },
-                        "yallist": {
-                            "version": "3.0.2",
-                            "bundled": true
                         }
+                    }
+                },
+                "term-size": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "execa": "^0.7.0"
                     }
                 },
                 "text-table": {
                     "version": "0.2.0",
+                    "bundled": true
+                },
+                "through": {
+                    "version": "2.3.8",
+                    "bundled": true
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
+                    }
+                },
+                "timed-out": {
+                    "version": "4.0.1",
+                    "bundled": true
+                },
+                "tiny-relative-date": {
+                    "version": "1.3.0",
+                    "bundled": true
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "bundled": true,
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "^5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "typedarray": {
+                    "version": "0.0.6",
                     "bundled": true
                 },
                 "uid-number": {
@@ -3314,609 +3190,166 @@
                     "bundled": true
                 },
                 "unique-filename": {
-                    "version": "1.1.0",
+                    "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "unique-slug": "2.0.0"
-                    },
-                    "dependencies": {
-                        "unique-slug": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "imurmurhash": "0.1.4"
-                            }
-                        }
+                        "unique-slug": "^2.0.0"
+                    }
+                },
+                "unique-slug": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4"
+                    }
+                },
+                "unique-string": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "crypto-random-string": "^1.0.0"
                     }
                 },
                 "unpipe": {
                     "version": "1.0.0",
                     "bundled": true
                 },
+                "unzip-response": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
                 "update-notifier": {
-                    "version": "2.3.0",
+                    "version": "2.5.0",
                     "bundled": true,
                     "requires": {
-                        "boxen": "1.2.1",
-                        "chalk": "2.1.0",
-                        "configstore": "3.1.1",
-                        "import-lazy": "2.1.0",
-                        "is-installed-globally": "0.1.0",
-                        "is-npm": "1.0.0",
-                        "latest-version": "3.1.0",
-                        "semver-diff": "2.1.0",
-                        "xdg-basedir": "3.0.0"
-                    },
-                    "dependencies": {
-                        "boxen": {
-                            "version": "1.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-align": "2.0.0",
-                                "camelcase": "4.1.0",
-                                "chalk": "2.1.0",
-                                "cli-boxes": "1.0.0",
-                                "string-width": "2.1.1",
-                                "term-size": "1.2.0",
-                                "widest-line": "1.0.0"
-                            },
-                            "dependencies": {
-                                "ansi-align": {
-                                    "version": "2.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "string-width": "2.1.1"
-                                    }
-                                },
-                                "camelcase": {
-                                    "version": "4.1.0",
-                                    "bundled": true
-                                },
-                                "cli-boxes": {
-                                    "version": "1.0.0",
-                                    "bundled": true
-                                },
-                                "string-width": {
-                                    "version": "2.1.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-fullwidth-code-point": "2.0.0",
-                                        "strip-ansi": "4.0.0"
-                                    },
-                                    "dependencies": {
-                                        "is-fullwidth-code-point": {
-                                            "version": "2.0.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "term-size": {
-                                    "version": "1.2.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "execa": "0.7.0"
-                                    },
-                                    "dependencies": {
-                                        "execa": {
-                                            "version": "0.7.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "cross-spawn": "5.1.0",
-                                                "get-stream": "3.0.0",
-                                                "is-stream": "1.1.0",
-                                                "npm-run-path": "2.0.2",
-                                                "p-finally": "1.0.0",
-                                                "signal-exit": "3.0.2",
-                                                "strip-eof": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "cross-spawn": {
-                                                    "version": "5.1.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "lru-cache": "4.1.1",
-                                                        "shebang-command": "1.2.0",
-                                                        "which": "1.3.0"
-                                                    },
-                                                    "dependencies": {
-                                                        "shebang-command": {
-                                                            "version": "1.2.0",
-                                                            "bundled": true,
-                                                            "requires": {
-                                                                "shebang-regex": "1.0.0"
-                                                            },
-                                                            "dependencies": {
-                                                                "shebang-regex": {
-                                                                    "version": "1.0.0",
-                                                                    "bundled": true
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "get-stream": {
-                                                    "version": "3.0.0",
-                                                    "bundled": true
-                                                },
-                                                "is-stream": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                },
-                                                "npm-run-path": {
-                                                    "version": "2.0.2",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "path-key": "2.0.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "path-key": {
-                                                            "version": "2.0.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                },
-                                                "p-finally": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                },
-                                                "signal-exit": {
-                                                    "version": "3.0.2",
-                                                    "bundled": true
-                                                },
-                                                "strip-eof": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "widest-line": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "string-width": "1.0.2"
-                                    },
-                                    "dependencies": {
-                                        "string-width": {
-                                            "version": "1.0.2",
-                                            "bundled": true,
-                                            "requires": {
-                                                "code-point-at": "1.1.0",
-                                                "is-fullwidth-code-point": "1.0.0",
-                                                "strip-ansi": "3.0.1"
-                                            },
-                                            "dependencies": {
-                                                "code-point-at": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                },
-                                                "is-fullwidth-code-point": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "number-is-nan": "1.0.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "number-is-nan": {
-                                                            "version": "1.0.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                },
-                                                "strip-ansi": {
-                                                    "version": "3.0.1",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "ansi-regex": "2.1.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "ansi-regex": {
-                                                            "version": "2.1.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "ansi-styles": "3.2.0",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "4.4.0"
-                            },
-                            "dependencies": {
-                                "ansi-styles": {
-                                    "version": "3.2.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "color-convert": "1.9.0"
-                                    },
-                                    "dependencies": {
-                                        "color-convert": {
-                                            "version": "1.9.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "color-name": "1.1.3"
-                                            },
-                                            "dependencies": {
-                                                "color-name": {
-                                                    "version": "1.1.3",
-                                                    "bundled": true
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "escape-string-regexp": {
-                                    "version": "1.0.5",
-                                    "bundled": true
-                                },
-                                "supports-color": {
-                                    "version": "4.4.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "has-flag": "2.0.0"
-                                    },
-                                    "dependencies": {
-                                        "has-flag": {
-                                            "version": "2.0.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "configstore": {
-                            "version": "3.1.1",
-                            "bundled": true,
-                            "requires": {
-                                "dot-prop": "4.2.0",
-                                "graceful-fs": "4.1.11",
-                                "make-dir": "1.0.0",
-                                "unique-string": "1.0.0",
-                                "write-file-atomic": "2.1.0",
-                                "xdg-basedir": "3.0.0"
-                            },
-                            "dependencies": {
-                                "dot-prop": {
-                                    "version": "4.2.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "is-obj": "1.0.1"
-                                    },
-                                    "dependencies": {
-                                        "is-obj": {
-                                            "version": "1.0.1",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "make-dir": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "pify": "2.3.0"
-                                    },
-                                    "dependencies": {
-                                        "pify": {
-                                            "version": "2.3.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                },
-                                "unique-string": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "crypto-random-string": "1.0.0"
-                                    },
-                                    "dependencies": {
-                                        "crypto-random-string": {
-                                            "version": "1.0.0",
-                                            "bundled": true
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "import-lazy": {
-                            "version": "2.1.0",
-                            "bundled": true
-                        },
-                        "is-installed-globally": {
-                            "version": "0.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "global-dirs": "0.1.0",
-                                "is-path-inside": "1.0.0"
-                            },
-                            "dependencies": {
-                                "global-dirs": {
-                                    "version": "0.1.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "ini": "1.3.5"
-                                    }
-                                },
-                                "is-path-inside": {
-                                    "version": "1.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "path-is-inside": "1.0.2"
-                                    }
-                                }
-                            }
-                        },
-                        "is-npm": {
-                            "version": "1.0.0",
-                            "bundled": true
-                        },
-                        "latest-version": {
-                            "version": "3.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "package-json": "4.0.1"
-                            },
-                            "dependencies": {
-                                "package-json": {
-                                    "version": "4.0.1",
-                                    "bundled": true,
-                                    "requires": {
-                                        "got": "6.7.1",
-                                        "registry-auth-token": "3.3.1",
-                                        "registry-url": "3.1.0",
-                                        "semver": "5.5.0"
-                                    },
-                                    "dependencies": {
-                                        "got": {
-                                            "version": "6.7.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "create-error-class": "3.0.2",
-                                                "duplexer3": "0.1.4",
-                                                "get-stream": "3.0.0",
-                                                "is-redirect": "1.0.0",
-                                                "is-retry-allowed": "1.1.0",
-                                                "is-stream": "1.1.0",
-                                                "lowercase-keys": "1.0.0",
-                                                "safe-buffer": "5.1.1",
-                                                "timed-out": "4.0.1",
-                                                "unzip-response": "2.0.1",
-                                                "url-parse-lax": "1.0.0"
-                                            },
-                                            "dependencies": {
-                                                "create-error-class": {
-                                                    "version": "3.0.2",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "capture-stack-trace": "1.0.0"
-                                                    },
-                                                    "dependencies": {
-                                                        "capture-stack-trace": {
-                                                            "version": "1.0.0",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                },
-                                                "duplexer3": {
-                                                    "version": "0.1.4",
-                                                    "bundled": true
-                                                },
-                                                "get-stream": {
-                                                    "version": "3.0.0",
-                                                    "bundled": true
-                                                },
-                                                "is-redirect": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                },
-                                                "is-retry-allowed": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                },
-                                                "is-stream": {
-                                                    "version": "1.1.0",
-                                                    "bundled": true
-                                                },
-                                                "lowercase-keys": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true
-                                                },
-                                                "timed-out": {
-                                                    "version": "4.0.1",
-                                                    "bundled": true
-                                                },
-                                                "unzip-response": {
-                                                    "version": "2.0.1",
-                                                    "bundled": true
-                                                },
-                                                "url-parse-lax": {
-                                                    "version": "1.0.0",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "prepend-http": "1.0.4"
-                                                    },
-                                                    "dependencies": {
-                                                        "prepend-http": {
-                                                            "version": "1.0.4",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "registry-auth-token": {
-                                            "version": "3.3.1",
-                                            "bundled": true,
-                                            "requires": {
-                                                "rc": "1.2.1",
-                                                "safe-buffer": "5.1.1"
-                                            },
-                                            "dependencies": {
-                                                "rc": {
-                                                    "version": "1.2.1",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "deep-extend": "0.4.2",
-                                                        "ini": "1.3.5",
-                                                        "minimist": "1.2.0",
-                                                        "strip-json-comments": "2.0.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "deep-extend": {
-                                                            "version": "0.4.2",
-                                                            "bundled": true
-                                                        },
-                                                        "minimist": {
-                                                            "version": "1.2.0",
-                                                            "bundled": true
-                                                        },
-                                                        "strip-json-comments": {
-                                                            "version": "2.0.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "registry-url": {
-                                            "version": "3.1.0",
-                                            "bundled": true,
-                                            "requires": {
-                                                "rc": "1.2.1"
-                                            },
-                                            "dependencies": {
-                                                "rc": {
-                                                    "version": "1.2.1",
-                                                    "bundled": true,
-                                                    "requires": {
-                                                        "deep-extend": "0.4.2",
-                                                        "ini": "1.3.5",
-                                                        "minimist": "1.2.0",
-                                                        "strip-json-comments": "2.0.1"
-                                                    },
-                                                    "dependencies": {
-                                                        "deep-extend": {
-                                                            "version": "0.4.2",
-                                                            "bundled": true
-                                                        },
-                                                        "minimist": {
-                                                            "version": "1.2.0",
-                                                            "bundled": true
-                                                        },
-                                                        "strip-json-comments": {
-                                                            "version": "2.0.1",
-                                                            "bundled": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "semver-diff": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "requires": {
-                                "semver": "5.5.0"
-                            }
-                        },
-                        "xdg-basedir": {
-                            "version": "3.0.0",
-                            "bundled": true
-                        }
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-ci": "^1.0.10",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
+                    }
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "prepend-http": "^1.0.1"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "util-extend": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "util-promisify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "object.getownpropertydescriptors": "^2.0.3"
                     }
                 },
                 "uuid": {
-                    "version": "3.2.1",
+                    "version": "3.3.2",
                     "bundled": true
                 },
                 "validate-npm-package-license": {
-                    "version": "3.0.1",
+                    "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "spdx-correct": "1.0.2",
-                        "spdx-expression-parse": "1.0.4"
-                    },
-                    "dependencies": {
-                        "spdx-correct": {
-                            "version": "1.0.2",
-                            "bundled": true,
-                            "requires": {
-                                "spdx-license-ids": "1.2.2"
-                            },
-                            "dependencies": {
-                                "spdx-license-ids": {
-                                    "version": "1.2.2",
-                                    "bundled": true
-                                }
-                            }
-                        },
-                        "spdx-expression-parse": {
-                            "version": "1.0.4",
-                            "bundled": true
-                        }
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
                     }
                 },
                 "validate-npm-package-name": {
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "builtins": "1.0.3"
-                    },
-                    "dependencies": {
-                        "builtins": {
-                            "version": "1.0.3",
-                            "bundled": true
-                        }
+                        "builtins": "^1.0.3"
+                    }
+                },
+                "verror": {
+                    "version": "1.10.0",
+                    "bundled": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "^1.2.0"
+                    }
+                },
+                "wcwidth": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "defaults": "^1.0.3"
                     }
                 },
                 "which": {
-                    "version": "1.3.0",
+                    "version": "1.3.1",
                     "bundled": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^1.0.2"
                     },
                     "dependencies": {
-                        "isexe": {
-                            "version": "2.0.0",
-                            "bundled": true
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
                         }
                     }
                 },
-                "worker-farm": {
-                    "version": "1.5.2",
+                "widest-line": {
+                    "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "xtend": "4.0.1"
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "worker-farm": {
+                    "version": "1.7.0",
+                    "bundled": true,
+                    "requires": {
+                        "errno": "~0.1.7"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                     },
                     "dependencies": {
-                        "errno": {
-                            "version": "0.1.7",
+                        "string-width": {
+                            "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "prr": "1.0.1"
-                            },
-                            "dependencies": {
-                                "prr": {
-                                    "version": "1.0.1",
-                                    "bundled": true
-                                }
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
-                        },
-                        "xtend": {
-                            "version": "4.0.1",
-                            "bundled": true
                         }
                     }
                 },
@@ -3925,14 +3358,358 @@
                     "bundled": true
                 },
                 "write-file-atomic": {
-                    "version": "2.1.0",
+                    "version": "2.4.3",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "slide": "1.1.6"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "xdg-basedir": {
+                    "version": "3.0.0",
+                    "bundled": true
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "bundled": true
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "bundled": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true
+                },
+                "yargs": {
+                    "version": "11.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "y18n": {
+                            "version": "3.2.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
                     }
                 }
+            }
+        },
+        "npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "optional": true,
+            "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "optional": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "optional": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "optional": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "osc": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/osc/-/osc-2.3.1.tgz",
+            "integrity": "sha512-7kT91FXuCQBpy0NVcXZRLAqBHJlDA3ECXZBMTLwQdgF7N+M2ODVMR06Hp9Yr/qsIl7K3A60Z3rpDJizW9BGvQQ==",
+            "requires": {
+                "long": "4.0.0",
+                "serialport": "7.1.5",
+                "slip": "1.0.2",
+                "wolfy87-eventemitter": "5.2.6",
+                "ws": "7.0.0"
+            }
+        },
+        "prebuild-install": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.2.tgz",
+            "integrity": "sha512-INDfXzTPnhT+WYQemqnAXlP7SvfiFMopMozSgXCZ+RDLb279gKfIuLk4o7PgEawLp3WrMgIYGBpkxpraROHsSA==",
+            "optional": true,
+            "requires": {
+                "detect-libc": "^1.0.3",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "napi-build-utils": "^1.0.1",
+                "node-abi": "^2.7.0",
+                "noop-logger": "^0.1.1",
+                "npmlog": "^4.0.1",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^3.0.3",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0",
+                "which-pm-runs": "^1.0.0"
+            }
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "optional": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "optional": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "optional": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "optional": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "optional": true
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "optional": true
+        },
+        "serialport": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/serialport/-/serialport-7.1.5.tgz",
+            "integrity": "sha512-NplGdqaY+ZL8t3t5egbT+3oqLW4d7WvDT/x1ACxAyWa1fSnx+KTAmlDHeCls39lXwu8voaOr3bPOW4bwM7PdAA==",
+            "optional": true,
+            "requires": {
+                "@serialport/binding-mock": "^2.0.5",
+                "@serialport/bindings": "^2.0.8",
+                "@serialport/parser-byte-length": "^2.0.2",
+                "@serialport/parser-cctalk": "^2.0.2",
+                "@serialport/parser-delimiter": "^2.0.2",
+                "@serialport/parser-readline": "^2.0.2",
+                "@serialport/parser-ready": "^2.0.2",
+                "@serialport/parser-regex": "^2.0.2",
+                "@serialport/stream": "^2.0.5",
+                "debug": "^4.1.1"
+            }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "optional": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "optional": true
+        },
+        "simple-concat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+            "optional": true
+        },
+        "simple-get": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "optional": true,
+            "requires": {
+                "decompress-response": "^4.2.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
+        },
+        "slip": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/slip/-/slip-1.0.2.tgz",
+            "integrity": "sha1-ukWpIwNNbPQbGieuvnEoKCyNVR8="
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "optional": true,
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "optional": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "optional": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "optional": true
+        },
+        "tar-fs": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+            "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+            "optional": true,
+            "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp": "^0.5.1",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.0.0"
+            }
+        },
+        "tar-stream": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+            "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+            "optional": true,
+            "requires": {
+                "bl": "^3.0.0",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+                    "optional": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "optional": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "optional": true
+        },
+        "which-pm-runs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+            "optional": true
+        },
+        "wide-align": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "optional": true,
+            "requires": {
+                "string-width": "^1.0.2 || 2"
+            }
+        },
+        "wolfy87-eventemitter": {
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.6.tgz",
+            "integrity": "sha512-n+bSucT1j9ZEoosxnfuH81bWqtZG4QEtZ9WEuiXz9YQAHEktGYKoSoMTKWTJEcYux8lWoqp1KqHPBpwvJKFFTw=="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "optional": true
+        },
+        "ws": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.0.tgz",
+            "integrity": "sha512-cknCal4k0EAOrh1SHHPPWWh4qm93g1IuGGGwBjWkXmCG7LsDtL8w9w+YVfaF+KSVwiHQKDIMsSLBVftKf9d1pg==",
+            "requires": {
+                "async-limiter": "^1.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "node-cmd": "^3.0.0",
         "node-omxplayer": "^0.6.1",
-        "npm": "^5.7.1",
-        "osc": "2.2.0"
+        "npm": "^6.12.0",
+        "osc": "2.3.1"
     }
 }


### PR DESCRIPTION
I had to update packages to successfully build osc-node with Node 10.
I think install.sh script may need some updates as well to install Node 10 and npm (which didn't install automatically when I ran the script).